### PR TITLE
add admin route for checking project storage usage

### DIFF
--- a/packages/web/src/hooks/useAdminQueries.ts
+++ b/packages/web/src/hooks/useAdminQueries.ts
@@ -92,6 +92,20 @@ export function useAdminProjectDetails(projectId: string | null | undefined) {
   });
 }
 
+export function useAdminProjectDocStats(projectId: string | null | undefined) {
+  return useQuery({
+    queryKey: queryKeys.admin.projectDocStats(projectId),
+    queryFn: () =>
+      parseResponse(
+        api.api.admin.projects[':projectId']['doc-stats'].$get({
+          param: { projectId: projectId! },
+        }),
+      ),
+    enabled: !!projectId,
+    ...ADMIN_QUERY_CONFIG,
+  });
+}
+
 export function useStorageDocuments(
   params: { cursor?: string | null; limit?: number; prefix?: string; search?: string } = {},
 ) {

--- a/packages/web/src/lib/queryKeys.ts
+++ b/packages/web/src/lib/queryKeys.ts
@@ -64,6 +64,8 @@ export const queryKeys = {
       ['adminProjects', page, limit, search, orgId] as const,
     projectDetails: (projectId: string | null | undefined) =>
       ['adminProjectDetails', projectId] as const,
+    projectDocStats: (projectId: string | null | undefined) =>
+      ['adminProjectDocStats', projectId] as const,
     storageDocuments: (cursor: string | null, limit: number, prefix: string, search: string) =>
       ['storageDocuments', cursor, limit, prefix, search] as const,
     storageStats: ['storageStats'] as const,

--- a/packages/web/src/routes/_app/_protected/admin/projects.$projectId.tsx
+++ b/packages/web/src/routes/_app/_protected/admin/projects.$projectId.tsx
@@ -21,9 +21,11 @@ import {
   CopyIcon,
   HardDriveIcon,
   UserMinusIcon,
+  DatabaseIcon,
+  RefreshCwIcon,
 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useAdminProjectDetails } from '@/hooks/useAdminQueries';
+import { useAdminProjectDetails, useAdminProjectDocStats } from '@/hooks/useAdminQueries';
 import { useAdminStore, removeProjectMember, deleteProject } from '@/stores/adminStore';
 import { showToast } from '@/components/ui/toast';
 import { UserAvatar } from '@/components/ui/avatar';
@@ -173,6 +175,27 @@ function ProjectDetailPage() {
 
   const projectQuery = useAdminProjectDetails(projectId);
   const projectData = projectQuery.data as ProjectData | undefined;
+
+  // DO storage stats are fetched separately because they route through the
+  // ProjectDoc DO and are slower than the D1 details query. Loading them as
+  // a sibling query lets the rest of the page render immediately.
+  const docStatsQuery = useAdminProjectDocStats(projectId);
+  const docStats = docStatsQuery.data as
+    | {
+        rows: {
+          total: number;
+          snapshot: number;
+          update: number;
+          snapshotBytes: number;
+          updateBytes: number;
+          totalBytes: number;
+        };
+        encodedSnapshotBytes: number;
+        memoryUsagePercent: number;
+        content: { members: number; studies: number; checklists: number; pdfs: number };
+        timestamps: { oldestRowAt: number | null; newestRowAt: number | null };
+      }
+    | undefined;
 
   const [confirmDialog, setConfirmDialog] = useState<{
     type: 'delete-project' | 'remove-member';
@@ -388,6 +411,161 @@ function ProjectDetailPage() {
                 </dd>
               </div>
             </dl>
+          </AdminBox>
+
+          {/* Y.Doc Storage Section
+           *
+           * Shows the live state of the project's Yjs document in the
+           * ProjectDoc DO. Most important number is `encodedSnapshotBytes`
+           * because that's the value that binds against the 128 MB DO
+           * isolate memory limit. Row counts show the on-disk shape (how
+           * many snapshot chunks vs incremental update rows). Logical
+           * counts give a feel for what's actually in the project. */}
+          <AdminBox className='mb-6'>
+            <div className='mb-4 flex items-center justify-between'>
+              <h2 className='text-foreground flex items-center text-lg font-semibold'>
+                <DatabaseIcon className='text-muted-foreground/70 mr-2 size-5' />
+                Y.Doc Storage
+              </h2>
+              <button
+                type='button'
+                onClick={() => docStatsQuery.refetch()}
+                disabled={docStatsQuery.isFetching}
+                className='text-muted-foreground hover:text-foreground inline-flex items-center text-sm disabled:opacity-50'
+                title='Refresh stats (wakes the DO if hibernating)'
+              >
+                <RefreshCwIcon
+                  className={`mr-1 size-4 ${docStatsQuery.isFetching ? 'animate-spin' : ''}`}
+                />
+                Refresh
+              </button>
+            </div>
+
+            {docStatsQuery.isLoading ?
+              <div className='text-muted-foreground flex items-center text-sm'>
+                <LoaderIcon className='mr-2 size-4 animate-spin' />
+                Loading storage stats...
+              </div>
+            : docStatsQuery.isError ?
+              <div className='flex items-center text-sm text-red-600'>
+                <AlertCircleIcon className='mr-2 size-4' />
+                Failed to load storage stats. The DO may be unreachable.
+              </div>
+            : docStats ?
+              <div className='space-y-6'>
+                {/* Headline: encoded size + memory usage */}
+                <div className='grid grid-cols-1 gap-4 md:grid-cols-3'>
+                  <div className='bg-muted/40 rounded-md p-4'>
+                    <dt className='text-muted-foreground text-xs font-medium uppercase tracking-wide'>
+                      Encoded Snapshot
+                    </dt>
+                    <dd className='text-foreground mt-1 text-2xl font-semibold'>
+                      {formatBytes(docStats.encodedSnapshotBytes)}
+                    </dd>
+                    <dd className='text-muted-foreground mt-1 text-xs'>
+                      Live `Y.encodeStateAsUpdate(doc)` size
+                    </dd>
+                  </div>
+                  <div className='bg-muted/40 rounded-md p-4'>
+                    <dt className='text-muted-foreground text-xs font-medium uppercase tracking-wide'>
+                      Memory Usage
+                    </dt>
+                    <dd
+                      className={`mt-1 text-2xl font-semibold ${
+                        docStats.memoryUsagePercent > 50 ? 'text-red-600'
+                        : docStats.memoryUsagePercent > 20 ? 'text-amber-600'
+                        : 'text-foreground'
+                      }`}
+                    >
+                      {docStats.memoryUsagePercent < 0.01 ?
+                        '< 0.01%'
+                      : `${docStats.memoryUsagePercent.toFixed(2)}%`}
+                    </dd>
+                    <dd className='text-muted-foreground mt-1 text-xs'>
+                      of 128 MB DO isolate limit
+                    </dd>
+                  </div>
+                  <div className='bg-muted/40 rounded-md p-4'>
+                    <dt className='text-muted-foreground text-xs font-medium uppercase tracking-wide'>
+                      On-Disk Total
+                    </dt>
+                    <dd className='text-foreground mt-1 text-2xl font-semibold'>
+                      {formatBytes(docStats.rows.totalBytes)}
+                    </dd>
+                    <dd className='text-muted-foreground mt-1 text-xs'>
+                      {docStats.rows.total} row{docStats.rows.total === 1 ? '' : 's'} in
+                      yjs_updates
+                    </dd>
+                  </div>
+                </div>
+
+                {/* Row breakdown by kind */}
+                <div>
+                  <h3 className='text-foreground mb-2 text-sm font-medium'>Row Breakdown</h3>
+                  <dl className='grid grid-cols-2 gap-4 md:grid-cols-4'>
+                    <div>
+                      <dt className='text-muted-foreground text-xs'>Snapshot Rows</dt>
+                      <dd className='text-foreground mt-1 text-sm font-medium'>
+                        {docStats.rows.snapshot} ({formatBytes(docStats.rows.snapshotBytes)})
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className='text-muted-foreground text-xs'>Update Rows</dt>
+                      <dd className='text-foreground mt-1 text-sm font-medium'>
+                        {docStats.rows.update} ({formatBytes(docStats.rows.updateBytes)})
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className='text-muted-foreground text-xs'>Oldest Row</dt>
+                      <dd className='text-foreground mt-1 text-sm font-medium'>
+                        {docStats.timestamps.oldestRowAt ?
+                          formatDate(new Date(docStats.timestamps.oldestRowAt))
+                        : '-'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className='text-muted-foreground text-xs'>Newest Row</dt>
+                      <dd className='text-foreground mt-1 text-sm font-medium'>
+                        {docStats.timestamps.newestRowAt ?
+                          formatDate(new Date(docStats.timestamps.newestRowAt))
+                        : '-'}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+
+                {/* Logical content counts */}
+                <div>
+                  <h3 className='text-foreground mb-2 text-sm font-medium'>Logical Content</h3>
+                  <dl className='grid grid-cols-2 gap-4 md:grid-cols-4'>
+                    <div>
+                      <dt className='text-muted-foreground text-xs'>Members</dt>
+                      <dd className='text-foreground mt-1 text-sm font-medium'>
+                        {docStats.content.members}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className='text-muted-foreground text-xs'>Studies</dt>
+                      <dd className='text-foreground mt-1 text-sm font-medium'>
+                        {docStats.content.studies}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className='text-muted-foreground text-xs'>Checklists</dt>
+                      <dd className='text-foreground mt-1 text-sm font-medium'>
+                        {docStats.content.checklists}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className='text-muted-foreground text-xs'>PDFs</dt>
+                      <dd className='text-foreground mt-1 text-sm font-medium'>
+                        {docStats.content.pdfs}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              </div>
+            : null}
           </AdminBox>
 
           {/* Members Section */}

--- a/packages/web/src/routes/_app/_protected/admin/projects.$projectId.tsx
+++ b/packages/web/src/routes/_app/_protected/admin/projects.$projectId.tsx
@@ -456,7 +456,7 @@ function ProjectDetailPage() {
                 {/* Headline: encoded size + memory usage */}
                 <div className='grid grid-cols-1 gap-4 md:grid-cols-3'>
                   <div className='bg-muted/40 rounded-md p-4'>
-                    <dt className='text-muted-foreground text-xs font-medium uppercase tracking-wide'>
+                    <dt className='text-muted-foreground text-xs font-medium tracking-wide uppercase'>
                       Encoded Snapshot
                     </dt>
                     <dd className='text-foreground mt-1 text-2xl font-semibold'>
@@ -467,7 +467,7 @@ function ProjectDetailPage() {
                     </dd>
                   </div>
                   <div className='bg-muted/40 rounded-md p-4'>
-                    <dt className='text-muted-foreground text-xs font-medium uppercase tracking-wide'>
+                    <dt className='text-muted-foreground text-xs font-medium tracking-wide uppercase'>
                       Memory Usage
                     </dt>
                     <dd
@@ -486,15 +486,14 @@ function ProjectDetailPage() {
                     </dd>
                   </div>
                   <div className='bg-muted/40 rounded-md p-4'>
-                    <dt className='text-muted-foreground text-xs font-medium uppercase tracking-wide'>
+                    <dt className='text-muted-foreground text-xs font-medium tracking-wide uppercase'>
                       On-Disk Total
                     </dt>
                     <dd className='text-foreground mt-1 text-2xl font-semibold'>
                       {formatBytes(docStats.rows.totalBytes)}
                     </dd>
                     <dd className='text-muted-foreground mt-1 text-xs'>
-                      {docStats.rows.total} row{docStats.rows.total === 1 ? '' : 's'} in
-                      yjs_updates
+                      {docStats.rows.total} row{docStats.rows.total === 1 ? '' : 's'} in yjs_updates
                     </dd>
                   </div>
                 </div>

--- a/packages/workers/src/durable-objects/ProjectDoc.ts
+++ b/packages/workers/src/durable-objects/ProjectDoc.ts
@@ -182,6 +182,52 @@ interface Pdf {
 }
 
 /**
+ * Result of `ProjectDoc.getStorageStats()`. Used by the admin dashboard
+ * to surface DO storage metrics for an individual project.
+ *
+ * `encodedSnapshotBytes` is the size of `Y.encodeStateAsUpdate(doc)` right
+ * now, which is the value that actually matters against the 128 MB DO
+ * isolate memory limit. The row-level numbers in `rows` show how the data
+ * is currently arranged on disk (snapshot chunks vs incremental updates).
+ */
+export interface ProjectDocStorageStats {
+  rows: {
+    total: number;
+    snapshot: number;
+    update: number;
+    snapshotBytes: number;
+    updateBytes: number;
+    totalBytes: number;
+  };
+  encodedSnapshotBytes: number;
+  /** Encoded snapshot size as a percentage of the 128 MB DO isolate memory limit. */
+  memoryUsagePercent: number;
+  content: {
+    members: number;
+    studies: number;
+    checklists: number;
+    pdfs: number;
+  };
+  timestamps: {
+    /** ms since epoch — the created_at of the lowest-seq row, or null if empty. */
+    oldestRowAt: number | null;
+    /** ms since epoch — the created_at of the highest-seq row, or null if empty. */
+    newestRowAt: number | null;
+  };
+}
+
+/**
+ * The 128 MB Cloudflare Workers/DO isolate memory limit. The Y.Doc lives
+ * in the JS heap inside this isolate, so encoded snapshot size is bounded
+ * by this number minus headroom for the in-memory Y.Doc representation,
+ * the encoding buffer during compaction, and runtime overhead. We expose
+ * `memoryUsagePercent` against this constant for the admin dashboard.
+ *
+ * Source: https://developers.cloudflare.com/workers/platform/limits/
+ */
+const DO_ISOLATE_MEMORY_BYTES = 128 * 1024 * 1024;
+
+/**
  * ProjectDoc Durable Object
  *
  * WARNING: HIGH BLAST RADIUS FILE
@@ -193,13 +239,6 @@ interface Pdf {
  * - WebSocket connections for all active users
  * - Member authorization for project access
  * - Awareness protocol (user presence indicators)
- *
- * BEFORE MODIFYING:
- * 1. Read: .cursor/rules/yjs-sync.mdc and durable-objects.mdc
- * 2. Run full test suite: cd packages/workers && pnpm test
- * 3. Test with multiple concurrent browser clients
- * 4. Verify WebSocket close codes don't break reconnection
- * 5. Check that member sync updates reflect correctly
  *
  * See: packages/docs/guides/yjs-sync.md for architecture details
  *
@@ -459,6 +498,108 @@ export class ProjectDoc extends DurableObject<Env> {
     }
 
     return result;
+  }
+
+  /**
+   * RPC: Return DO storage stats for the admin dashboard.
+   *
+   * Read-only. Computes:
+   *  - Row counts and byte totals broken down by `kind` (snapshot vs update)
+   *  - The encoded snapshot size of the current in-memory Y.Doc — this is
+   *    the value that binds against the 128 MB isolate memory limit, not
+   *    the on-disk row totals
+   *  - Logical content counts (members, studies, checklists, pdfs)
+   *  - Timestamps of the oldest and newest rows for back-of-the-envelope
+   *    "how active is this project" questions
+   *
+   * Initialization is mandatory because computing the encoded size and
+   * the logical counts both require an in-memory Y.Doc.
+   */
+  async getStorageStats(): Promise<ProjectDocStorageStats> {
+    await this.initializeDoc();
+
+    // Row-level breakdown by kind. We use a single query so we never read
+    // a partial view of the table mid-write. The COALESCE on the SUM
+    // protects against the empty-table case where SUM returns NULL.
+    const breakdown = this.ctx.storage.sql
+      .exec<{ kind: string; n: number; bytes: number }>(
+        `SELECT kind, COUNT(*) AS n, COALESCE(SUM(LENGTH(payload)), 0) AS bytes
+         FROM yjs_updates
+         GROUP BY kind`,
+      )
+      .toArray();
+
+    let snapshotRows = 0;
+    let updateRows = 0;
+    let snapshotBytes = 0;
+    let updateBytes = 0;
+    for (const row of breakdown) {
+      if (row.kind === 'snapshot') {
+        snapshotRows = row.n;
+        snapshotBytes = row.bytes;
+      } else if (row.kind === 'update') {
+        updateRows = row.n;
+        updateBytes = row.bytes;
+      }
+    }
+
+    // Oldest / newest row timestamps for "how stale is this snapshot" view.
+    // Two cheap queries on indexed columns.
+    const oldest = this.ctx.storage.sql
+      .exec<{ created_at: number }>('SELECT created_at FROM yjs_updates ORDER BY seq ASC LIMIT 1')
+      .toArray();
+    const newest = this.ctx.storage.sql
+      .exec<{ created_at: number }>('SELECT created_at FROM yjs_updates ORDER BY seq DESC LIMIT 1')
+      .toArray();
+
+    // The number that actually matters: the encoded snapshot size right
+    // now. This is what compaction would write and what determines the
+    // memory pressure on the next cold load.
+    const encodedSnapshotBytes = Y.encodeStateAsUpdate(this.doc!).byteLength;
+    const memoryUsagePercent = (encodedSnapshotBytes / DO_ISOLATE_MEMORY_BYTES) * 100;
+
+    // Logical content counts. We walk the doc maps directly rather than
+    // routing through the dev export path because we only need counts.
+    const membersMap = this.doc!.getMap('members');
+    const reviewsMap = this.doc!.getMap('reviews');
+    let studies = 0;
+    let checklists = 0;
+    let pdfs = 0;
+    for (const reviewValue of reviewsMap.values()) {
+      studies++;
+      const reviewYMap = reviewValue as Y.Map<unknown>;
+      const checklistsMap = reviewYMap.get('checklists') as Y.Map<unknown> | undefined;
+      if (checklistsMap && typeof checklistsMap.entries === 'function') {
+        checklists += checklistsMap.size;
+      }
+      const pdfsMap = reviewYMap.get('pdfs') as Y.Map<unknown> | undefined;
+      if (pdfsMap && typeof pdfsMap.entries === 'function') {
+        pdfs += pdfsMap.size;
+      }
+    }
+
+    return {
+      rows: {
+        total: snapshotRows + updateRows,
+        snapshot: snapshotRows,
+        update: updateRows,
+        snapshotBytes,
+        updateBytes,
+        totalBytes: snapshotBytes + updateBytes,
+      },
+      encodedSnapshotBytes,
+      memoryUsagePercent,
+      content: {
+        members: membersMap.size,
+        studies,
+        checklists,
+        pdfs,
+      },
+      timestamps: {
+        oldestRowAt: oldest[0]?.created_at ?? null,
+        newestRowAt: newest[0]?.created_at ?? null,
+      },
+    };
   }
 
   // --- Dev RPC methods (only callable when DEV_MODE is enabled) ---

--- a/packages/workers/src/durable-objects/__tests__/ProjectDoc.rpc.test.ts
+++ b/packages/workers/src/durable-objects/__tests__/ProjectDoc.rpc.test.ts
@@ -223,4 +223,148 @@ describe('ProjectDoc RPC Persistence', () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // getStorageStats: read-only RPC used by the admin dashboard
+  // ---------------------------------------------------------------------------
+  describe('getStorageStats', () => {
+    // Use a fresh project ID per test so we can assert exact row counts and
+    // content totals without bleed-over from sibling tests in the same file.
+    let statsProjectIdCounter = 0;
+
+    function getStatsStub() {
+      statsProjectIdCounter++;
+      const doName = `project:stats-test-${statsProjectIdCounter}`;
+      const id = env.PROJECT_DOC.idFromName(doName);
+      return env.PROJECT_DOC.get(id);
+    }
+
+    it('returns zero counts and zero bytes for an empty doc', async () => {
+      const stub = getStatsStub();
+      // Trigger initialization without making any logical changes. We call
+      // syncProject with an empty members list so the doc is initialised but
+      // no content lives inside it.
+      await stub.syncProject({ members: [] });
+
+      const stats = await stub.getStorageStats();
+
+      expect(stats.content.members).toBe(0);
+      expect(stats.content.studies).toBe(0);
+      expect(stats.content.checklists).toBe(0);
+      expect(stats.content.pdfs).toBe(0);
+      // The encoded snapshot of an "empty" doc is non-zero (it carries
+      // a state vector header) but it's tiny.
+      expect(stats.encodedSnapshotBytes).toBeGreaterThanOrEqual(0);
+      expect(stats.encodedSnapshotBytes).toBeLessThan(1024);
+      expect(stats.memoryUsagePercent).toBeLessThan(0.01);
+    });
+
+    it('returns correct content counts for a populated doc', async () => {
+      const stub = getStatsStub();
+
+      // Seed members
+      await stub.syncProject({
+        meta: { name: 'stats-populated' },
+        members: [
+          { userId: 'u1', role: 'owner', name: 'Owner', email: 'o@test.com' },
+          { userId: 'u2', role: 'member', name: 'Member 1', email: 'm1@test.com' },
+          { userId: 'u3', role: 'member', name: 'Member 2', email: 'm2@test.com' },
+        ],
+      });
+
+      // Seed two studies, each with a PDF
+      await stub.syncPdf({
+        action: 'add',
+        studyId: 'study-1',
+        studyName: 'Study 1',
+        pdf: {
+          key: 'r2-1',
+          fileName: 'paper-1.pdf',
+          size: 1024,
+          uploadedBy: 'u1',
+          uploadedAt: new Date().toISOString(),
+        },
+      });
+      await stub.syncPdf({
+        action: 'add',
+        studyId: 'study-2',
+        studyName: 'Study 2',
+        pdf: {
+          key: 'r2-2',
+          fileName: 'paper-2.pdf',
+          size: 2048,
+          uploadedBy: 'u1',
+          uploadedAt: new Date().toISOString(),
+        },
+      });
+
+      const stats = await stub.getStorageStats();
+
+      expect(stats.content.members).toBe(3);
+      expect(stats.content.studies).toBe(2);
+      expect(stats.content.pdfs).toBe(2);
+      // No checklists were added — syncPdf only creates the study + pdfs
+      expect(stats.content.checklists).toBe(0);
+
+      // Row totals should match what's in the table
+      expect(stats.rows.total).toBeGreaterThan(0);
+      expect(stats.rows.totalBytes).toBe(stats.rows.snapshotBytes + stats.rows.updateBytes);
+
+      // Encoded snapshot should be non-trivial since we have real content
+      expect(stats.encodedSnapshotBytes).toBeGreaterThan(50);
+
+      // Timestamps populated
+      expect(stats.timestamps.oldestRowAt).not.toBeNull();
+      expect(stats.timestamps.newestRowAt).not.toBeNull();
+      expect(stats.timestamps.newestRowAt!).toBeGreaterThanOrEqual(
+        stats.timestamps.oldestRowAt!,
+      );
+    });
+
+    it('reports row breakdown by kind correctly after compaction', async () => {
+      const stub = getStatsStub();
+
+      // Force a few rows to accumulate
+      for (let i = 0; i < 5; i++) {
+        await stub.syncMember('add', {
+          userId: `c${i}`,
+          role: 'member',
+          name: `C${i}`,
+          email: `c${i}@test.com`,
+        });
+      }
+
+      // Stats before compaction: should be all update rows
+      const beforeStats = await stub.getStorageStats();
+      expect(beforeStats.rows.update).toBeGreaterThan(0);
+      expect(beforeStats.rows.snapshot).toBe(0);
+
+      // Manually compact to produce snapshot rows
+      await runInDurableObject(stub, async (instance: ProjectDoc, _state) => {
+        (instance as unknown as { compact(): void }).compact();
+      });
+
+      const afterStats = await stub.getStorageStats();
+      expect(afterStats.rows.snapshot).toBeGreaterThan(0);
+      expect(afterStats.rows.update).toBe(0);
+      expect(afterStats.rows.total).toBe(afterStats.rows.snapshot);
+      // Content counts unchanged by compaction (compaction doesn't lose data)
+      expect(afterStats.content.members).toBe(beforeStats.content.members);
+    });
+
+    it('memoryUsagePercent is encoded size as a percentage of 128 MB', async () => {
+      const stub = getStatsStub();
+      await stub.syncMember('add', {
+        userId: 'mem-pct',
+        role: 'owner',
+        name: 'Pct Test',
+        email: 'p@test.com',
+      });
+
+      const stats = await stub.getStorageStats();
+      const expected = (stats.encodedSnapshotBytes / (128 * 1024 * 1024)) * 100;
+      // Allow tiny floating-point drift
+      expect(Math.abs(stats.memoryUsagePercent - expected)).toBeLessThan(1e-9);
+    });
+  });
 });

--- a/packages/workers/src/durable-objects/__tests__/ProjectDoc.rpc.test.ts
+++ b/packages/workers/src/durable-objects/__tests__/ProjectDoc.rpc.test.ts
@@ -316,9 +316,7 @@ describe('ProjectDoc RPC Persistence', () => {
       // Timestamps populated
       expect(stats.timestamps.oldestRowAt).not.toBeNull();
       expect(stats.timestamps.newestRowAt).not.toBeNull();
-      expect(stats.timestamps.newestRowAt!).toBeGreaterThanOrEqual(
-        stats.timestamps.oldestRowAt!,
-      );
+      expect(stats.timestamps.newestRowAt!).toBeGreaterThanOrEqual(stats.timestamps.oldestRowAt!);
     });
 
     it('reports row breakdown by kind correctly after compaction', async () => {

--- a/packages/workers/src/routes/admin/__tests__/admin-projects.test.ts
+++ b/packages/workers/src/routes/admin/__tests__/admin-projects.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for admin project routes.
+ *
+ * Currently focused on the doc-stats endpoint added with the chunked-snapshot
+ * persistence redesign — it routes through a Durable Object (the only admin
+ * project route that does), so the 404-without-waking-the-DO behavior and
+ * the response shape both deserve coverage.
+ *
+ * The full project listing / details / delete routes are already covered by
+ * end-to-end tests against the Hono router elsewhere; this file is scoped to
+ * the doc-stats path.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono, type Context } from 'hono';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import {
+  resetTestDatabase,
+  seedUser,
+  seedOrganization,
+  seedProject,
+  clearProjectDOs,
+} from '@/__tests__/helpers.js';
+
+vi.mock('@/middleware/requireAdmin.js', () => {
+  return {
+    isAdmin: () => true,
+    requireAdmin: async (c: Context, next: () => Promise<void>) => {
+      c.set('user', {
+        id: 'admin-user',
+        role: 'admin',
+        email: 'admin@example.com',
+        name: 'Admin User',
+      });
+      c.set('session', { id: 'admin-session' });
+      c.set('isAdmin', true);
+      await next();
+    },
+  };
+});
+
+let app: Hono;
+
+interface FetchInit extends RequestInit {
+  headers?: Record<string, string>;
+}
+
+async function fetchApp(path: string, init: FetchInit = {}) {
+  const ctx = createExecutionContext();
+  const req = new Request(`http://localhost${path}`, {
+    ...init,
+    headers: {
+      origin: 'http://localhost:5173',
+      ...init.headers,
+    },
+  });
+  const res = await app.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+beforeAll(async () => {
+  const { projectRoutes } = await import('../projects.js');
+  app = new Hono();
+  app.route('/api/admin', projectRoutes);
+});
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  await clearProjectDOs(['admin-stats-project', 'admin-stats-populated']);
+  vi.clearAllMocks();
+});
+
+describe('GET /api/admin/projects/:projectId/doc-stats', () => {
+  it('returns 404 when the project does not exist in D1', async () => {
+    const res = await fetchApp('/api/admin/projects/no-such-project/doc-stats');
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { code?: string };
+    // The exact code comes from createDomainError(PROJECT_ERRORS.NOT_FOUND)
+    expect(body).toBeDefined();
+  });
+
+  it('returns 200 with stat shape for an existing empty project', async () => {
+    const now = Math.floor(Date.now() / 1000);
+
+    // Seed the minimum required for the route's D1 existence check to pass.
+    await seedUser({
+      id: 'owner-1',
+      email: 'owner@example.com',
+      name: 'Owner',
+      createdAt: now,
+      updatedAt: now,
+    });
+    await seedOrganization({
+      id: 'org-stats',
+      name: 'Org',
+      slug: 'org-stats',
+      createdAt: now,
+    });
+    await seedProject({
+      id: 'admin-stats-project',
+      name: 'Stats Test Project',
+      orgId: 'org-stats',
+      createdBy: 'owner-1',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const res = await fetchApp('/api/admin/projects/admin-stats-project/doc-stats');
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      rows: {
+        total: number;
+        snapshot: number;
+        update: number;
+        snapshotBytes: number;
+        updateBytes: number;
+        totalBytes: number;
+      };
+      encodedSnapshotBytes: number;
+      memoryUsagePercent: number;
+      content: { members: number; studies: number; checklists: number; pdfs: number };
+      timestamps: { oldestRowAt: number | null; newestRowAt: number | null };
+    };
+
+    // Shape assertions
+    expect(typeof body.rows.total).toBe('number');
+    expect(typeof body.rows.snapshot).toBe('number');
+    expect(typeof body.rows.update).toBe('number');
+    expect(typeof body.encodedSnapshotBytes).toBe('number');
+    expect(typeof body.memoryUsagePercent).toBe('number');
+    expect(typeof body.content.members).toBe('number');
+    expect(typeof body.content.studies).toBe('number');
+    expect(typeof body.content.checklists).toBe('number');
+    expect(typeof body.content.pdfs).toBe('number');
+
+    // Empty doc invariants
+    expect(body.content.members).toBe(0);
+    expect(body.content.studies).toBe(0);
+    expect(body.content.checklists).toBe(0);
+    expect(body.content.pdfs).toBe(0);
+    expect(body.memoryUsagePercent).toBeLessThan(0.01);
+
+    // Cross-field consistency
+    expect(body.rows.totalBytes).toBe(body.rows.snapshotBytes + body.rows.updateBytes);
+  });
+});

--- a/packages/workers/src/routes/admin/projects.ts
+++ b/packages/workers/src/routes/admin/projects.ts
@@ -141,6 +141,35 @@ const SuccessResponseSchema = z
   })
   .openapi('AdminProjectSuccessResponse');
 
+// Mirrors `ProjectDocStorageStats` from ProjectDoc.ts. We define the
+// schema here rather than importing the type so this route file owns its
+// own contract — the underlying RPC method can return additional fields
+// without breaking the API surface, and Zod validation catches any drift.
+const ProjectDocStatsResponseSchema = z
+  .object({
+    rows: z.object({
+      total: z.number(),
+      snapshot: z.number(),
+      update: z.number(),
+      snapshotBytes: z.number(),
+      updateBytes: z.number(),
+      totalBytes: z.number(),
+    }),
+    encodedSnapshotBytes: z.number(),
+    memoryUsagePercent: z.number(),
+    content: z.object({
+      members: z.number(),
+      studies: z.number(),
+      checklists: z.number(),
+      pdfs: z.number(),
+    }),
+    timestamps: z.object({
+      oldestRowAt: z.number().nullable(),
+      newestRowAt: z.number().nullable(),
+    }),
+  })
+  .openapi('AdminProjectDocStatsResponse');
+
 // Route definitions
 const listProjectsRoute = createRoute({
   method: 'get',
@@ -231,6 +260,46 @@ const getProjectDetailsRoute = createRoute({
     },
     500: {
       description: 'Database error',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+const getProjectDocStatsRoute = createRoute({
+  method: 'get',
+  path: '/projects/{projectId}/doc-stats',
+  tags: ['Admin - Projects'],
+  summary: 'Get project Y.Doc storage stats',
+  description:
+    'Returns DO SQLite row counts, byte totals, encoded snapshot size, and logical content counts for a single project. Used by the admin dashboard to surface storage growth and memory pressure. Admin only.',
+  request: {
+    params: z.object({
+      projectId: z.string().openapi({ description: 'Project ID', example: 'proj-123' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Project doc storage stats',
+      content: {
+        'application/json': {
+          schema: ProjectDocStatsResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Project not found',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+    500: {
+      description: 'Internal error',
       content: {
         'application/json': {
           schema: ErrorResponseSchema,
@@ -582,6 +651,48 @@ const projectRoutes = base
     } catch (err) {
       const error = err as Error;
       console.error('Error fetching admin project detail:', error);
+      const dbError = createDomainError(SYSTEM_ERRORS.DB_ERROR, {
+        message: error.message,
+      });
+      return c.json(dbError, 500);
+    }
+  })
+
+  /**
+   * GET /api/admin/projects/:projectId/doc-stats
+   * Return DO storage stats (rows, byte totals, encoded snapshot size,
+   * memory usage %, and logical content counts) for a single project.
+   *
+   * This routes to the ProjectDoc DO and reads its in-memory state, so the
+   * DO is woken if it was hibernating. The 404 path checks D1 first to
+   * avoid waking a DO for a project that doesn't exist.
+   */
+  .openapi(getProjectDocStatsRoute, async c => {
+    const { projectId } = c.req.valid('param');
+    const db = createDb(c.env.DB);
+
+    try {
+      // Verify the project exists in D1 before touching the DO. Without
+      // this we'd wake a stub for any random ID and the DO would happily
+      // initialize an empty doc.
+      const [project] = await db
+        .select({ id: projects.id })
+        .from(projects)
+        .where(eq(projects.id, projectId))
+        .limit(1);
+
+      if (!project) {
+        const error = createDomainError(PROJECT_ERRORS.NOT_FOUND, { projectId });
+        return c.json(error, 404);
+      }
+
+      const { getProjectDocStub } = await import('@/lib/project-doc-id.js');
+      const projectDoc = getProjectDocStub(c.env, projectId);
+      const stats = await projectDoc.getStorageStats();
+      return c.json(stats, 200);
+    } catch (err) {
+      const error = err as Error;
+      console.error('Error fetching project doc stats:', error);
       const dbError = createDomainError(SYSTEM_ERRORS.DB_ERROR, {
         message: error.message,
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin project document storage statistics dashboard displaying snapshot size, memory usage percentage with visual indicators, row counts by data type, modification timestamps, and logical content metrics (members, studies, checklists, PDFs) with manual refresh capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->