### PR TITLE
Unify local + collab checklists, generic updateChecklistAnswer

### DIFF
--- a/packages/web/e2e/amstar2-workflow.spec.ts
+++ b/packages/web/e2e/amstar2-workflow.spec.ts
@@ -15,7 +15,7 @@ import {
   switchUser,
   type DualReviewerScenario,
 } from './helpers';
-import { setupProjectWithStudy, markChecklistComplete } from './shared-steps';
+import { setupProjectWithStudy, markChecklistComplete, answerAllAMSTAR2 } from './shared-steps';
 
 let scenario: DualReviewerScenario;
 
@@ -43,13 +43,7 @@ test('Dual-Reviewer AMSTAR2 Workflow', async ({ context, page }) => {
   await expect(page).toHaveURL(/\/checklists\//, { timeout: 10_000 });
   await page.waitForTimeout(2000);
 
-  // Answer all questions "Yes"
-  const yesRadios = page.getByRole('radio', { name: 'Yes' });
-  const count = await yesRadios.count();
-  for (let i = 0; i < count; i++) {
-    await yesRadios.nth(i).click();
-  }
-  await page.waitForTimeout(1000);
+  await answerAllAMSTAR2(page, 'Yes');
 
   await markChecklistComplete(page);
   await page.goto(`/projects/${projectId}`);
@@ -87,13 +81,7 @@ test('Dual-Reviewer AMSTAR2 Workflow', async ({ context, page }) => {
     await page.waitForTimeout(2000);
   }
 
-  // Answer all questions "No"
-  const noRadios = page.getByRole('radio', { name: 'No' });
-  const noCount = await noRadios.count();
-  for (let i = 0; i < noCount; i++) {
-    await noRadios.nth(i).click();
-  }
-  await page.waitForTimeout(1000);
+  await answerAllAMSTAR2(page, 'No');
 
   await markChecklistComplete(page);
   await page.goto(`/projects/${projectId}`);

--- a/packages/web/e2e/local-checklist.spec.ts
+++ b/packages/web/e2e/local-checklist.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * E2E Test: Local-practice checklist persistence
+ *
+ * Local appraisals live in a Y.Doc persisted via y-dexie under the
+ * `local-practice` project id (no WebSocket provider). This test verifies
+ * that answers round-trip through the full pipeline:
+ *   UI patch → handlePartialUpdate → buildChecklistAnswerInput
+ *     → updateChecklistAnswer (typed) → handler.updateAnswer
+ *     → Y.Map → DexieYProvider → reload → restored state
+ *
+ * Covers AMSTAR2 (boolean-matrix per question) and ROB2 (discriminated
+ * per-key schemas). ROBINS-I shares ROB2's shape-family so we skip it here;
+ * the dual-reviewer workflow tests exercise both handlers' typed dispatch
+ * via the collab path.
+ *
+ * No auth needed — /checklist is a public route (see routes/_app.tsx).
+ *
+ * Prerequisites:
+ *   pnpm --filter web dev  (localhost:3010)
+ */
+
+import { test, expect } from '@playwright/test';
+import { answerAllAMSTAR2, fillROB2Preliminary } from './shared-steps';
+
+async function createLocalChecklist(
+  page: import('@playwright/test').Page,
+  type: 'AMSTAR2' | 'ROB2' | 'ROBINS_I',
+  name: string,
+) {
+  await page.goto('/checklist');
+  await expect(page.getByRole('heading', { name: /Start an Appraisal/i })).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await page.locator('#checklist-type').selectOption(type);
+  await page.locator('#checklist-name').fill(name);
+  await page.getByRole('button', { name: /^Start$/ }).click();
+
+  await expect(page).toHaveURL(/\/checklist\/[0-9a-f-]{36}/, { timeout: 10_000 });
+  // Wait for the "Loading checklist..." gate to clear (phase === 'synced').
+  await expect(page.getByText('Loading checklist...')).toBeHidden({ timeout: 15_000 });
+}
+
+test.describe('Local-practice checklists', () => {
+  test('AMSTAR2: answers persist across reload', async ({ page }) => {
+    await createLocalChecklist(page, 'AMSTAR2', 'Local AMSTAR2 Test');
+
+    await answerAllAMSTAR2(page, 'Yes');
+
+    const checkedBefore = await page.getByRole('radio', { name: 'Yes', checked: true }).count();
+    expect(checkedBefore).toBeGreaterThan(0);
+
+    await page.reload();
+    await expect(page.getByText('Loading checklist...')).toBeHidden({ timeout: 15_000 });
+
+    // Give the Y.Doc a beat to hydrate from IndexedDB before reading state.
+    await page.waitForTimeout(1000);
+
+    const checkedAfter = await page.getByRole('radio', { name: 'Yes', checked: true }).count();
+    expect(checkedAfter).toBe(checkedBefore);
+  });
+
+  test('ROB2: preliminary fields persist across reload', async ({ page }) => {
+    await createLocalChecklist(page, 'ROB2', 'Local ROB2 Test');
+
+    await fillROB2Preliminary(page, 'Drug X', 'Placebo');
+
+    await page.reload();
+    await expect(page.getByText('Loading checklist...')).toBeHidden({ timeout: 15_000 });
+    await page.waitForTimeout(1000);
+
+    // Y.Text fields round-trip via getTextRef + DexieYProvider.
+    await expect(page.getByPlaceholder(/experimental intervention/i)).toHaveValue('Drug X');
+    await expect(page.getByPlaceholder(/comparator intervention/i)).toHaveValue('Placebo');
+    await expect(page.getByPlaceholder(/e\.g\. RR/i)).toHaveValue('RR 1.5');
+  });
+});

--- a/packages/web/e2e/rob2-workflow.spec.ts
+++ b/packages/web/e2e/rob2-workflow.spec.ts
@@ -16,7 +16,13 @@ import {
   switchUser,
   type DualReviewerScenario,
 } from './helpers';
-import { setupProjectWithStudy, addOutcome, markChecklistComplete } from './shared-steps';
+import {
+  setupProjectWithStudy,
+  addOutcome,
+  markChecklistComplete,
+  fillROB2Preliminary,
+  answerAllROB2Domains,
+} from './shared-steps';
 
 let scenario: DualReviewerScenario;
 
@@ -27,43 +33,6 @@ test.beforeAll(async () => {
 test.afterAll(async () => {
   if (scenario) await cleanupScenario(scenario);
 });
-
-/** Fill the ROB2 preliminary section and select assessment aim */
-async function fillROB2Preliminary(
-  page: import('@playwright/test').Page,
-  intervention: string,
-  comparator: string,
-) {
-  await page.getByText('Individually-randomized parallel-group trial').click();
-
-  // Select aim BEFORE filling text fields to avoid the bug where aim
-  // selection was overwriting Y.Text fields with empty values.
-  const aimBtn = page.getByText('to assess the effect of assignment to intervention');
-  await aimBtn.scrollIntoViewIfNeeded();
-  await aimBtn.click();
-  await page.waitForTimeout(500);
-
-  await page.getByPlaceholder(/experimental intervention/i).fill(intervention);
-  await page.getByPlaceholder(/comparator intervention/i).fill(comparator);
-  await page.getByPlaceholder(/e\.g\. RR/i).fill('RR 1.5');
-  await page.waitForTimeout(500);
-}
-
-/** Answer all ROB2 domain questions with a given response (Y or N) */
-async function answerAllROB2Domains(page: import('@playwright/test').Page, answer: string) {
-  for (const domain of ['D1', 'D2', 'D3', 'D4', 'D5']) {
-    await page.getByRole('button', { name: domain, exact: true }).click();
-    await page.waitForTimeout(500);
-
-    const buttons = page.getByRole('button', { name: answer, exact: true });
-    const count = await buttons.count();
-    for (let i = 0; i < count; i++) {
-      await buttons.nth(i).click();
-      await page.waitForTimeout(100);
-    }
-    await page.waitForTimeout(300);
-  }
-}
 
 test('Dual-Reviewer ROB2 Workflow', async ({ context, page }) => {
   const projectId = await setupProjectWithStudy(context, page, scenario, 'ROB2 E2E Test');

--- a/packages/web/e2e/shared-steps.ts
+++ b/packages/web/e2e/shared-steps.ts
@@ -6,6 +6,54 @@ import path from 'node:path';
 import { expect, type Page, type BrowserContext } from '@playwright/test';
 import { loginAs, addProjectMember, type DualReviewerScenario } from './helpers';
 
+/** Click every radio on the AMSTAR2 checklist editor matching the given answer (e.g. "Yes", "No"). */
+export async function answerAllAMSTAR2(page: Page, answer: 'Yes' | 'No' | 'Partial Yes') {
+  const radios = page.getByRole('radio', { name: answer });
+  const count = await radios.count();
+  for (let i = 0; i < count; i++) {
+    await radios.nth(i).click();
+  }
+  await page.waitForTimeout(1000);
+}
+
+/** Fill the ROB2 preliminary section: study design, aim, interventions, numerical result. */
+export async function fillROB2Preliminary(
+  page: Page,
+  intervention: string,
+  comparator: string,
+  numericalResult = 'RR 1.5',
+) {
+  await page.getByText('Individually-randomized parallel-group trial').click();
+
+  // Select aim BEFORE filling text fields to avoid the bug where aim
+  // selection was overwriting Y.Text fields with empty values.
+  const aimBtn = page.getByText('to assess the effect of assignment to intervention');
+  await aimBtn.scrollIntoViewIfNeeded();
+  await aimBtn.click();
+  await page.waitForTimeout(500);
+
+  await page.getByPlaceholder(/experimental intervention/i).fill(intervention);
+  await page.getByPlaceholder(/comparator intervention/i).fill(comparator);
+  await page.getByPlaceholder(/e\.g\. RR/i).fill(numericalResult);
+  await page.waitForTimeout(500);
+}
+
+/** Answer every ROB2 domain signalling question with a given response (Y, N, PY, PN, NI). */
+export async function answerAllROB2Domains(page: Page, answer: string) {
+  for (const domain of ['D1', 'D2', 'D3', 'D4', 'D5']) {
+    await page.getByRole('button', { name: domain, exact: true }).click();
+    await page.waitForTimeout(500);
+
+    const buttons = page.getByRole('button', { name: answer, exact: true });
+    const count = await buttons.count();
+    for (let i = 0; i < count; i++) {
+      await buttons.nth(i).click();
+      await page.waitForTimeout(100);
+    }
+    await page.waitForTimeout(300);
+  }
+}
+
 const FIXTURES_DIR = path.join(import.meta.dirname, 'fixtures');
 
 /**

--- a/packages/web/src/components/checklist/ChecklistYjsWrapper.tsx
+++ b/packages/web/src/components/checklist/ChecklistYjsWrapper.tsx
@@ -9,7 +9,7 @@ import { ChevronLeftIcon } from 'lucide-react';
 import { ChecklistWithPdf } from '@/components/checklist/ChecklistWithPdf';
 import { useProjectContext } from '@/components/project/ProjectContext';
 import { connectionPool } from '@/project/ConnectionPool';
-import { useChecklistAnswers } from '@/primitives/useProject/checklists/useChecklistAnswers';
+import { useChecklistViewModel } from '@/primitives/useProject/checklists/useChecklistViewModel';
 import { useProjectStore, selectConnectionPhase } from '@/stores/projectStore';
 import { useAuthStore, selectUser } from '@/stores/authStore';
 import { ACCESS_DENIED_ERRORS } from '@/constants/errors.js';
@@ -27,7 +27,6 @@ import {
   AlertDialogFooter,
   AlertDialogAction,
 } from '@/components/ui/alert-dialog';
-import { getChecklistTypeFromState, scoreChecklistOfType } from '@/checklist-registry/index';
 import { ScoreTag } from '@/components/checklist/ScoreTag';
 import { isAMSTAR2Complete } from '@/components/checklist/AMSTAR2Checklist/checklist.js';
 import { isROBINSIComplete } from '@/components/checklist/ROBINSIChecklist/checklist';
@@ -97,15 +96,8 @@ export function ChecklistYjsWrapper({ projectId, studyId, checklistId }: Checkli
     }
   }, [connectionState.error, navigate]);
 
-  const currentStudy = useProjectStore(s => {
-    const studies = s.projects[projectId]?.studies || [];
-    return studies.find((st: any) => st.id === studyId) || null;
-  });
-
-  const currentChecklist = useMemo(() => {
-    if (!currentStudy) return null;
-    return currentStudy.checklists?.find((c: any) => c.id === checklistId) || null;
-  }, [currentStudy, checklistId]);
+  const { currentStudy, currentChecklist, checklistForUI, checklistType, currentScore } =
+    useChecklistViewModel(projectId, studyId, checklistId);
 
   const isReadOnly = currentChecklist?.status ? !isEditable(currentChecklist.status) : false;
 
@@ -213,30 +205,6 @@ export function ChecklistYjsWrapper({ projectId, studyId, checklistId }: Checkli
     },
     [orgId, projectId, studyId, studyPdfs, user?.id, addPdfToStudy],
   );
-
-  const answers = useChecklistAnswers(projectId, studyId, checklistId);
-
-  const checklistForUI = useMemo(() => {
-    if (!currentChecklist || !answers) return null;
-    return {
-      id: currentChecklist.id,
-      name: currentStudy?.name || 'Checklist',
-      reviewerName: '',
-      createdAt: currentChecklist.createdAt,
-      ...answers,
-    };
-  }, [currentChecklist, currentStudy, answers]);
-
-  const checklistType = useMemo(() => {
-    if (currentChecklist?.type) return currentChecklist.type;
-    if (checklistForUI) return getChecklistTypeFromState(checklistForUI);
-    return 'AMSTAR2';
-  }, [currentChecklist, checklistForUI]);
-
-  const currentScore = useMemo(() => {
-    if (!checklistForUI || !checklistType) return null;
-    return scoreChecklistOfType(checklistType, checklistForUI);
-  }, [checklistForUI, checklistType]);
 
   const isChecklistValid = useMemo(() => {
     if (!checklistForUI) return false;
@@ -374,7 +342,7 @@ export function ChecklistYjsWrapper({ projectId, studyId, checklistId }: Checkli
         </span>
       </div>
       <div className='ml-auto flex items-center gap-3'>
-        <ScoreTag currentScore={currentScore} checklistType={checklistType} />
+        <ScoreTag currentScore={currentScore} checklistType={checklistType ?? undefined} />
         {!isReadOnly ?
           <button
             onClick={handleToggleComplete}
@@ -425,7 +393,7 @@ export function ChecklistYjsWrapper({ projectId, studyId, checklistId }: Checkli
 
   return (
     <ChecklistWithPdf
-      checklistType={checklistType}
+      checklistType={checklistType ?? undefined}
       checklist={checklistForUI}
       onUpdate={handlePartialUpdate}
       headerContent={headerContent}

--- a/packages/web/src/components/checklist/ChecklistYjsWrapper.tsx
+++ b/packages/web/src/components/checklist/ChecklistYjsWrapper.tsx
@@ -10,6 +10,7 @@ import { ChecklistWithPdf } from '@/components/checklist/ChecklistWithPdf';
 import { useProjectContext } from '@/components/project/ProjectContext';
 import { connectionPool } from '@/project/ConnectionPool';
 import { useChecklistViewModel } from '@/primitives/useProject/checklists/useChecklistViewModel';
+import { buildChecklistAnswerInput } from '@/primitives/useProject/checklists';
 import { useProjectStore, selectConnectionPhase } from '@/stores/projectStore';
 import { useAuthStore, selectUser } from '@/stores/authStore';
 import { ACCESS_DENIED_ERRORS } from '@/constants/errors.js';
@@ -31,35 +32,6 @@ import { ScoreTag } from '@/components/checklist/ScoreTag';
 import { isAMSTAR2Complete } from '@/components/checklist/AMSTAR2Checklist/checklist.js';
 import { isROBINSIComplete } from '@/components/checklist/ROBINSIChecklist/checklist';
 import { isROB2Complete } from '@/components/checklist/ROB2Checklist/checklist';
-
-// Valid answer keys for each checklist type (module-level for stable references)
-const AMSTAR2_KEY_PATTERN = /^q\d+[a-z]*$/i;
-const ROBINS_I_KEYS = new Set([
-  'planning',
-  'sectionA',
-  'sectionB',
-  'sectionC',
-  'sectionD',
-  'confoundingEvaluation',
-  'domain1a',
-  'domain1b',
-  'domain2',
-  'domain3',
-  'domain4',
-  'domain5',
-  'domain6',
-  'overall',
-]);
-const ROB2_KEYS = new Set([
-  'preliminary',
-  'domain1',
-  'domain2a',
-  'domain2b',
-  'domain3',
-  'domain4',
-  'domain5',
-  'overall',
-]);
 
 interface ChecklistYjsWrapperProps {
   projectId: string;
@@ -216,15 +188,11 @@ export function ChecklistYjsWrapper({ projectId, studyId, checklistId }: Checkli
 
   const handlePartialUpdate = useCallback(
     (patch: Record<string, any>) => {
-      if (isReadOnly) return;
+      if (isReadOnly || !checklistType) return;
       Object.entries(patch).forEach(([key, value]) => {
-        const isValidKey =
-          (checklistType === 'AMSTAR2' && AMSTAR2_KEY_PATTERN.test(key)) ||
-          (checklistType === 'ROBINS_I' && ROBINS_I_KEYS.has(key)) ||
-          (checklistType === 'ROB2' && ROB2_KEYS.has(key));
-        if (isValidKey) {
-          updateChecklistAnswer(studyId, checklistId, key, value);
-        }
+        const input = buildChecklistAnswerInput(checklistType, key, value);
+        if (!input) return;
+        updateChecklistAnswer(studyId, checklistId, input);
       });
     },
     [isReadOnly, checklistType, updateChecklistAnswer, studyId, checklistId],

--- a/packages/web/src/components/checklist/LocalChecklistView.tsx
+++ b/packages/web/src/components/checklist/LocalChecklistView.tsx
@@ -6,7 +6,7 @@
  * they don't benefit from CRDT storage and would bloat the Y.Doc.
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { ChevronLeftIcon } from 'lucide-react';
 import * as Y from 'yjs';
@@ -14,11 +14,10 @@ import { ChecklistWithPdf } from '@/components/checklist/ChecklistWithPdf';
 import { CreateLocalChecklist } from '@/components/checklist/CreateLocalChecklist';
 import { connectionPool } from '@/project/ConnectionPool';
 import { LOCAL_PROJECT_ID } from '@/project/localProject';
-import { useProjectStore, selectConnectionPhase, selectStudies } from '@/stores/projectStore';
-import { useChecklistAnswers } from '@/primitives/useProject/checklists/useChecklistAnswers';
+import { useProjectStore, selectConnectionPhase } from '@/stores/projectStore';
+import { useChecklistViewModel } from '@/primitives/useProject/checklists/useChecklistViewModel';
 import type { TextRef } from '@/primitives/useProject/checklists';
 import { db } from '@/primitives/db';
-import { getChecklistTypeFromState, scoreChecklistOfType } from '@/checklist-registry/index';
 import { ScoreTag } from '@/components/checklist/ScoreTag';
 
 interface LocalChecklistViewProps {
@@ -37,18 +36,11 @@ function LocalChecklistEditor({ checklistId }: { checklistId: string }) {
   const navigate = useNavigate();
 
   const phase = useProjectStore(s => selectConnectionPhase(s, LOCAL_PROJECT_ID));
-  const studies = useProjectStore(s => selectStudies(s, LOCAL_PROJECT_ID));
-
-  const currentStudy = useMemo(
-    () => studies.find(st => st.id === checklistId) || null,
-    [studies, checklistId],
+  const { currentChecklist, checklistForUI, checklistType, currentScore } = useChecklistViewModel(
+    LOCAL_PROJECT_ID,
+    checklistId,
+    checklistId,
   );
-  const currentChecklist = useMemo(
-    () => (currentStudy?.checklists || []).find(c => c.id === checklistId) || null,
-    [currentStudy, checklistId],
-  );
-
-  const answers = useChecklistAnswers(LOCAL_PROJECT_ID, checklistId, checklistId);
 
   const [pdfState, setPdfState] = useState<{
     loading: boolean;
@@ -142,28 +134,6 @@ function LocalChecklistEditor({ checklistId }: { checklistId: string }) {
     },
     [checklistId],
   );
-
-  const checklistForUI = useMemo(() => {
-    if (!currentChecklist || !answers) return null;
-    return {
-      id: checklistId,
-      name: currentStudy?.name || 'Checklist',
-      reviewerName: '',
-      createdAt: currentChecklist.createdAt as number | undefined,
-      ...answers,
-    };
-  }, [currentChecklist, answers, checklistId, currentStudy?.name]);
-
-  const checklistType = useMemo(() => {
-    if (currentChecklist?.type) return currentChecklist.type;
-    if (checklistForUI) return getChecklistTypeFromState(checklistForUI);
-    return null;
-  }, [currentChecklist, checklistForUI]);
-
-  const currentScore = useMemo(() => {
-    if (!checklistForUI || !checklistType) return null;
-    return scoreChecklistOfType(checklistType, checklistForUI);
-  }, [checklistForUI, checklistType]);
 
   const handleBack = useCallback(() => {
     navigate({ to: '/dashboard' });

--- a/packages/web/src/components/checklist/LocalChecklistView.tsx
+++ b/packages/web/src/components/checklist/LocalChecklistView.tsx
@@ -16,7 +16,10 @@ import { connectionPool } from '@/project/ConnectionPool';
 import { LOCAL_PROJECT_ID } from '@/project/localProject';
 import { useProjectStore, selectConnectionPhase } from '@/stores/projectStore';
 import { useChecklistViewModel } from '@/primitives/useProject/checklists/useChecklistViewModel';
-import type { TextRef } from '@/primitives/useProject/checklists';
+import {
+  buildChecklistAnswerInput,
+  type TextRef,
+} from '@/primitives/useProject/checklists';
 import { db } from '@/primitives/db';
 import { ScoreTag } from '@/components/checklist/ScoreTag';
 
@@ -114,17 +117,14 @@ function LocalChecklistEditor({ checklistId }: { checklistId: string }) {
   const handlePartialUpdate = useCallback(
     (patch: Record<string, any>) => {
       const ops = connectionPool.getOps(LOCAL_PROJECT_ID);
-      if (!ops) return;
+      if (!ops || !checklistType) return;
       Object.entries(patch).forEach(([key, value]) => {
-        ops.checklist.updateChecklistAnswer(
-          checklistId,
-          checklistId,
-          key,
-          value as Record<string, unknown>,
-        );
+        const input = buildChecklistAnswerInput(checklistType, key, value);
+        if (!input) return;
+        ops.checklist.updateChecklistAnswer(checklistId, checklistId, input);
       });
     },
-    [checklistId],
+    [checklistId, checklistType],
   );
 
   const getTextRef = useCallback(

--- a/packages/web/src/components/checklist/LocalChecklistView.tsx
+++ b/packages/web/src/components/checklist/LocalChecklistView.tsx
@@ -16,10 +16,7 @@ import { connectionPool } from '@/project/ConnectionPool';
 import { LOCAL_PROJECT_ID } from '@/project/localProject';
 import { useProjectStore, selectConnectionPhase } from '@/stores/projectStore';
 import { useChecklistViewModel } from '@/primitives/useProject/checklists/useChecklistViewModel';
-import {
-  buildChecklistAnswerInput,
-  type TextRef,
-} from '@/primitives/useProject/checklists';
+import { buildChecklistAnswerInput, type TextRef } from '@/primitives/useProject/checklists';
 import { db } from '@/primitives/db';
 import { ScoreTag } from '@/components/checklist/ScoreTag';
 

--- a/packages/web/src/components/project/reconcile-tab/ReconciliationWrapper.tsx
+++ b/packages/web/src/components/project/reconcile-tab/ReconciliationWrapper.tsx
@@ -7,7 +7,10 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useProjectContext } from '@/components/project/ProjectContext';
 import { connectionPool } from '@/project/ConnectionPool';
-import type { TextRef } from '@/primitives/useProject/checklists';
+import {
+  buildChecklistAnswerInput,
+  type TextRef,
+} from '@/primitives/useProject/checklists';
 import {
   useProjectStore,
   selectMembers,
@@ -486,9 +489,11 @@ export function ReconciliationWrapper({
     <ReconciliationEngine
       {...sharedProps}
       checklistType={checklistType}
-      updateChecklistAnswer={(sectionKey: string, data: any) => {
+      updateChecklistAnswer={(sectionKey: string, data: unknown) => {
         if (!reconciledChecklistId) return;
-        updateChecklistAnswer(studyId, reconciledChecklistId, sectionKey, data);
+        const input = buildChecklistAnswerInput(checklistType, sectionKey, data);
+        if (!input) return;
+        updateChecklistAnswer(studyId, reconciledChecklistId, input);
       }}
       getTextRef={getTextRef}
       setTextValue={setTextValue}

--- a/packages/web/src/components/project/reconcile-tab/ReconciliationWrapper.tsx
+++ b/packages/web/src/components/project/reconcile-tab/ReconciliationWrapper.tsx
@@ -7,10 +7,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useProjectContext } from '@/components/project/ProjectContext';
 import { connectionPool } from '@/project/ConnectionPool';
-import {
-  buildChecklistAnswerInput,
-  type TextRef,
-} from '@/primitives/useProject/checklists';
+import { buildChecklistAnswerInput, type TextRef } from '@/primitives/useProject/checklists';
 import {
   useProjectStore,
   selectMembers,

--- a/packages/web/src/primitives/db.ts
+++ b/packages/web/src/primitives/db.ts
@@ -69,6 +69,10 @@ class CoratesDB extends Dexie {
   pdfs!: Table<PdfCacheRow, string>;
   avatars!: Table<AvatarRow, string>;
   formStates!: Table<FormStateRow, string>;
+  // TODO(agent): legacy table — kept for one release after the local-practice
+  // Y.Doc migration shipped on 2026-04-18 to give all devices a chance to run
+  // `migrateLocalChecklistsToYDoc`. Drop the table + the `LocalChecklistRow`
+  // type + `migrateLocalChecklistsToYDoc` once the rollback window has passed.
   localChecklists!: Table<LocalChecklistRow, string>;
   localChecklistPdfs!: Table<LocalChecklistPdfRow, string>;
 

--- a/packages/web/src/primitives/useProject/checklists/index.ts
+++ b/packages/web/src/primitives/useProject/checklists/index.ts
@@ -5,8 +5,11 @@
 
 import * as Y from 'yjs';
 import { AMSTAR2_KEY_SCHEMAS, isAmstar2Key } from '@corates/shared/checklists/amstar2';
+import type { Amstar2Key, Amstar2Answers } from '@corates/shared/checklists/amstar2';
 import { ROBINS_I_KEY_SCHEMAS, isRobinsIKey } from '@corates/shared/checklists/robins-i';
+import type { RobinsIKey, RobinsIAnswers } from '@corates/shared/checklists/robins-i';
 import { ROB2_KEY_SCHEMAS, isRob2Key } from '@corates/shared/checklists/rob2';
+import type { Rob2Key, Rob2Answers } from '@corates/shared/checklists/rob2';
 import { createChecklistOfType, CHECKLIST_TYPES } from '@/checklist-registry';
 import { CHECKLIST_STATUS } from '@/constants/checklist-status';
 import { createCommonOperations } from './common';
@@ -20,6 +23,47 @@ export type TextRef =
   | { type: 'AMSTAR2'; questionKey: string }
   | { type: 'ROBINS_I'; sectionKey: string; fieldKey: string; questionKey?: string | null }
   | { type: 'ROB2'; sectionKey: string; fieldKey: string; questionKey?: string | null };
+
+/**
+ * Discriminated input for `updateChecklistAnswer`. Each variant ties the
+ * `key` to the per-checklist key union and `data` to that key's answer
+ * payload type, so callers can't pass mismatched (type, key, data) triples.
+ */
+export type ChecklistAnswerInput =
+  | { [K in Amstar2Key]: { type: 'AMSTAR2'; key: K; data: Amstar2Answers[K] } }[Amstar2Key]
+  | { [K in RobinsIKey]: { type: 'ROBINS_I'; key: K; data: RobinsIAnswers[K] } }[RobinsIKey]
+  | { [K in Rob2Key]: { type: 'ROB2'; key: K; data: Rob2Answers[K] } }[Rob2Key];
+
+/**
+ * Narrow a (checklistType, key, data) triple coming from a dynamic patch into
+ * a typed `ChecklistAnswerInput`. Returns null when the key is not valid for
+ * the given checklist type. Data is asserted via `as` because patches arrive
+ * as `unknown` from React event handlers; the dispatcher's Zod parse catches
+ * any shape mismatch at runtime.
+ */
+export function buildChecklistAnswerInput(
+  checklistType: string,
+  key: string,
+  data: unknown,
+): ChecklistAnswerInput | null {
+  // The (key, data) correlation is a runtime fact; widening through the
+  // narrowed `key` would require a per-variant branch for every key. Cast
+  // through the variant once — the dispatcher's Zod parse validates `data`
+  // matches the schema for `key` at runtime.
+  switch (checklistType) {
+    case CHECKLIST_TYPES.AMSTAR2:
+      if (!isAmstar2Key(key)) return null;
+      return { type: 'AMSTAR2', key, data } as ChecklistAnswerInput;
+    case CHECKLIST_TYPES.ROBINS_I:
+      if (!isRobinsIKey(key)) return null;
+      return { type: 'ROBINS_I', key, data } as ChecklistAnswerInput;
+    case CHECKLIST_TYPES.ROB2:
+      if (!isRob2Key(key)) return null;
+      return { type: 'ROB2', key, data } as ChecklistAnswerInput;
+    default:
+      return null;
+  }
+}
 
 export interface ChecklistOperations {
   createChecklist: (
@@ -35,8 +79,7 @@ export interface ChecklistOperations {
   updateChecklistAnswer: (
     studyId: string,
     checklistId: string,
-    key: string,
-    data: Record<string, unknown>,
+    input: ChecklistAnswerInput,
   ) => void;
   getTextRef: (studyId: string, checklistId: string, ref: TextRef) => Y.Text | null;
   setTextValue: (
@@ -233,13 +276,17 @@ export function createChecklistOperations(
   function updateChecklistAnswer(
     studyId: string,
     checklistId: string,
-    key: string,
-    data: Record<string, unknown>,
+    input: ChecklistAnswerInput,
   ): void {
     const result = commonOps.getChecklistYMap(studyId, checklistId);
     if (!result) return;
 
     const { checklistYMap, checklistType } = result;
+    if (checklistType !== input.type) {
+      throw new Error(
+        `[updateChecklistAnswer] checklist ${checklistId} is type ${checklistType} but input was ${input.type}`,
+      );
+    }
 
     let answersMap = checklistYMap.get('answers') as Y.Map<unknown> | undefined;
     if (!answersMap) {
@@ -247,33 +294,25 @@ export function createChecklistOperations(
       checklistYMap.set('answers', answersMap);
     }
 
-    switch (checklistType) {
+    // The discriminated input pins (key, data) to the checklist type at the
+    // type level, but we still parse with Zod to catch external callers that
+    // bypass the type system with `as` casts.
+    switch (input.type) {
       case CHECKLIST_TYPES.AMSTAR2: {
-        if (!isAmstar2Key(key)) {
-          throw new Error(`[updateChecklistAnswer] Invalid AMSTAR2 key: ${key}`);
-        }
-        const parsed = AMSTAR2_KEY_SCHEMAS[key].parse(data);
-        amstar2Handler.updateAnswer(answersMap, key, parsed);
+        const parsed = AMSTAR2_KEY_SCHEMAS[input.key].parse(input.data);
+        amstar2Handler.updateAnswer(answersMap, input.key, parsed);
         break;
       }
       case CHECKLIST_TYPES.ROBINS_I: {
-        if (!isRobinsIKey(key)) {
-          throw new Error(`[updateChecklistAnswer] Invalid ROBINS-I key: ${key}`);
-        }
-        const parsed = ROBINS_I_KEY_SCHEMAS[key].parse(data);
-        robinsIHandler.updateAnswer(answersMap, key, parsed);
+        const parsed = ROBINS_I_KEY_SCHEMAS[input.key].parse(input.data);
+        robinsIHandler.updateAnswer(answersMap, input.key, parsed as RobinsIAnswers[RobinsIKey]);
         break;
       }
       case CHECKLIST_TYPES.ROB2: {
-        if (!isRob2Key(key)) {
-          throw new Error(`[updateChecklistAnswer] Invalid ROB2 key: ${key}`);
-        }
-        const parsed = ROB2_KEY_SCHEMAS[key].parse(data);
-        rob2Handler.updateAnswer(answersMap, key, parsed);
+        const parsed = ROB2_KEY_SCHEMAS[input.key].parse(input.data);
+        rob2Handler.updateAnswer(answersMap, input.key, parsed as Rob2Answers[Rob2Key]);
         break;
       }
-      default:
-        throw new Error(`[updateChecklistAnswer] Unknown checklist type: ${checklistType}`);
     }
 
     const currentStatus = checklistYMap.get('status');

--- a/packages/web/src/primitives/useProject/checklists/useChecklistViewModel.ts
+++ b/packages/web/src/primitives/useProject/checklists/useChecklistViewModel.ts
@@ -1,0 +1,64 @@
+/**
+ * Derives the view-model a checklist editor needs from the project Y.Doc:
+ * the study/checklist records, the flat answer object UI components consume,
+ * the checklist type, and the current score. Shared by both the collab view
+ * (`ChecklistYjsWrapper`) and the local-practice view (`LocalChecklistView`).
+ */
+
+import { useMemo } from 'react';
+import { useProjectStore, selectStudies } from '@/stores/projectStore';
+import type { StudyInfo, ChecklistInfo } from '@/stores/projectStore';
+import { getChecklistTypeFromState, scoreChecklistOfType } from '@/checklist-registry/index';
+import { useChecklistAnswers } from './useChecklistAnswers';
+
+export interface ChecklistViewModel {
+  currentStudy: StudyInfo | null;
+  currentChecklist: ChecklistInfo | null;
+  checklistForUI: Record<string, unknown> | null;
+  checklistType: string | null;
+  currentScore: string | null;
+}
+
+export function useChecklistViewModel(
+  projectId: string,
+  studyId: string,
+  checklistId: string,
+): ChecklistViewModel {
+  const studies = useProjectStore(s => selectStudies(s, projectId));
+
+  const currentStudy = useMemo(
+    () => studies.find(st => st.id === studyId) ?? null,
+    [studies, studyId],
+  );
+
+  const currentChecklist = useMemo(
+    () => (currentStudy?.checklists ?? []).find(c => c.id === checklistId) ?? null,
+    [currentStudy, checklistId],
+  );
+
+  const answers = useChecklistAnswers(projectId, studyId, checklistId);
+
+  const checklistForUI = useMemo(() => {
+    if (!currentChecklist || !answers) return null;
+    return {
+      id: currentChecklist.id,
+      name: currentStudy?.name ?? 'Checklist',
+      reviewerName: '',
+      createdAt: currentChecklist.createdAt as number | undefined,
+      ...answers,
+    };
+  }, [currentChecklist, currentStudy?.name, answers]);
+
+  const checklistType = useMemo(() => {
+    if (currentChecklist?.type) return currentChecklist.type;
+    if (checklistForUI) return getChecklistTypeFromState(checklistForUI);
+    return null;
+  }, [currentChecklist, checklistForUI]);
+
+  const currentScore = useMemo(() => {
+    if (!checklistForUI || !checklistType) return null;
+    return scoreChecklistOfType(checklistType, checklistForUI);
+  }, [checklistForUI, checklistType]);
+
+  return { currentStudy, currentChecklist, checklistForUI, checklistType, currentScore };
+}

--- a/packages/web/src/project/actions.ts
+++ b/packages/web/src/project/actions.ts
@@ -86,20 +86,6 @@ export const project = {
       return ops.checklist.getChecklistData(studyId, checklistId) ?? null;
     },
 
-    updateAnswer(
-      studyId: string,
-      checklistId: string,
-      questionId: string,
-      answer: unknown,
-      note?: string,
-    ): void {
-      const ops = connectionPool.getActiveOps();
-      if (!ops) throw new Error('No active project connection');
-      const data: Record<string, unknown> = { answer };
-      if (note !== undefined) data.note = note;
-      ops.checklist.updateChecklistAnswer(studyId, checklistId, questionId, data);
-    },
-
     getTextRef(studyId: string, checklistId: string, ref: TextRef) {
       const ops = connectionPool.getActiveOps();
       if (!ops) throw new Error('No active project connection');

--- a/packages/web/src/stores/projectStore.ts
+++ b/packages/web/src/stores/projectStore.ts
@@ -31,7 +31,7 @@ interface PdfInfo {
   [key: string]: unknown;
 }
 
-interface ChecklistInfo {
+export interface ChecklistInfo {
   id: string;
   type: string;
   status?: string;
@@ -42,7 +42,7 @@ interface ChecklistInfo {
   [key: string]: unknown;
 }
 
-interface StudyInfo {
+export interface StudyInfo {
   id: string;
   name: string;
   checklists?: ChecklistInfo[];


### PR DESCRIPTION
## Summary

Wraps up three refactor issues:

- **Closes #481** — Unify local-practice and collaborative checklists under a single Y.Doc shape
- **Closes #482** — Replace `Record<string, unknown>` answer payloads with typed per-checklist schemas
- **Closes #483** — Typed `project.*` API, unified text refs, and typed connection state (final piece; the prior text-ref + `project.*` work shipped in #491 and #492)

## What's in this PR

### #481 — Local + collab unification
- New `useChecklistViewModel(projectId, studyId, checklistId)` hook in `primitives/useProject/checklists/useChecklistViewModel.ts` that derives `{ currentStudy, currentChecklist, checklistForUI, checklistType, currentScore }` once. Replaces ~30 lines of duplicated `useMemo` chains in both views.
- `LocalChecklistView` and `ChecklistYjsWrapper` both call the new hook. `ChecklistInfo` and `StudyInfo` are exported from `projectStore.ts` so the hook can type its return.
- Kept `LocalChecklistView` as a separate thin component — it has genuinely different concerns (offline single-PDF in the `localChecklistPdfs` Dexie table, no annotations, no completion workflow, no `orgId`). Folding it into a unified view would buy ~30 lines and cost an `if (isLocal)` god-component.

### #482 — Generic `updateChecklistAnswer`
- New discriminated `ChecklistAnswerInput` union in `primitives/useProject/checklists/index.ts` ties `(type, key, data)` together at the type level — the old `Record<string, unknown>` is gone from the public API.
- New `buildChecklistAnswerInput(checklistType, key, data)` helper narrows dynamic patches into typed inputs. Used by `LocalChecklistView`, `ChecklistYjsWrapper`, and `ReconciliationWrapper`.
- Dropped the unused `project.checklist.updateAnswer` from `actions.ts`.
- Dispatcher still runs Zod parse at the boundary as runtime defense against external `as` casts.

### Deferred for #481 (intentional)
The legacy `localChecklists` Dexie table is **not** dropped in this PR. The Y.Doc migration shipped just hours before this work, and dropping the table now would orphan any device that hasn't reloaded the app since. Added a `TODO(agent)` on `db.ts:73-77` documenting when it's safe to remove (`migrateLocalChecklistsToYDoc` + table + `LocalChecklistRow` type, after the rollback window has passed).

## Test plan

- [x] `pnpm --filter web typecheck` clean
- [x] `pnpm --filter web test` — 407/407 passing
- [x] `pnpm --filter shared test` — 266/266 passing
- [ ] Manual: create a new local checklist, edit answers, reload — answers persist (Y.Doc round-trip)
- [ ] Manual: open a collab checklist, edit answers, verify sync still works
- [ ] Manual: enter reconciliation, navigate, verify auto-fill on agreement still writes typed updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated checklist data and scoring into a shared view model for more consistent behavior.
  * Centralized and strengthened checklist answer validation and update flow to reduce inconsistencies.

* **New Features**
  * Local (offline) checklist persistence and creation flow for quicker local practice sessions.

* **Tests**
  * New and reorganized end-to-end helpers and specs for AMSTAR2 and ROB2 to improve test reliability and reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->