### PR TITLE
ci: run e2e in Playwright container, split staging/prod deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,10 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
-  deploy-and-test:
+  # Build and deploy to staging. Gated on `checks` and push-only; this gate
+  # cascades to `e2e` and `deploy-production` via `needs` (a skipped dependency
+  # skips its dependents), so the whole deploy chain stays off pull requests.
+  deploy-staging:
     if: github.event_name == 'push'
     needs: checks
     runs-on: ubuntu-latest
@@ -112,8 +115,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      # -- Staging deploy --
 
       - name: Build workspace dependencies
         run: pnpm --filter @corates/shared --filter @corates/db build
@@ -147,12 +148,8 @@ jobs:
         working-directory: packages/stripe-purchases
         run: pnpm exec wrangler deploy --env staging
 
-      # -- E2E tests against staging --
-
-      - name: Install Playwright browsers
-        working-directory: packages/web
-        run: pnpm exec playwright install chromium --with-deps
-
+      # Confirm the deploy is live before handing off to the e2e job. Runs here
+      # (not in the e2e container) so we can rely on curl being present.
       - name: Wait for staging to be ready
         run: |
           for i in $(seq 1 30); do
@@ -165,6 +162,33 @@ jobs:
           done
           echo "Staging did not become ready in time"
           exit 1
+
+  # E2E against staging in the official Playwright container: browsers and their
+  # system deps are prebaked, so there is no install step. The image tag MUST
+  # match @playwright/test in the lockfile (1.59.1) or the browsers won't match.
+  e2e:
+    needs: deploy-staging
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run e2e tests
         env:
@@ -180,7 +204,31 @@ jobs:
           path: packages/web/test-results/
           retention-days: 7
 
-      # -- Production deploy (only if e2e tests pass) --
+  # Production deploy, gated on e2e passing (default success() on `needs`).
+  deploy-production:
+    needs: e2e
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: pnpm --filter @corates/shared --filter @corates/db build
 
       - name: Build web for production
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      # Resolved Playwright version, consumed by the e2e job's container tag so
+      # the image can never drift out of sync with @playwright/test.
+      playwright-version: ${{ steps.pw-version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -115,6 +119,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Resolve Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm --filter web exec playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
 
       - name: Build workspace dependencies
         run: pnpm --filter @corates/shared --filter @corates/db build
@@ -164,13 +172,14 @@ jobs:
           exit 1
 
   # E2E against staging in the official Playwright container: browsers and their
-  # system deps are prebaked, so there is no install step. The image tag MUST
-  # match @playwright/test in the lockfile (1.59.1) or the browsers won't match.
+  # system deps are prebaked, so there is no install step. The image tag is
+  # derived from the version deploy-staging resolved, so it always matches
+  # @playwright/test and cannot drift.
   e2e:
     needs: deploy-staging
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      image: mcr.microsoft.com/playwright:v${{ needs.deploy-staging.outputs.playwright-version }}-noble
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary

Refactors the monolithic `deploy-and-test` job into a three-job chain so e2e runs in the official Playwright container with zero browser-install time:

```
checks  ->  deploy-staging  ->  e2e (Playwright container)  ->  deploy-production
```

## Why

Previously a single job built, deployed staging, **installed Chromium + apt system deps from scratch every run** (`playwright install chromium --with-deps`, ~130 MB download + apt), ran e2e, then deployed prod. The browser install was uncached dead weight on every run.

## What changed

- **`deploy-staging`** — build + deploy web/stripe to staging, then the health-check wait (kept here so we can rely on `curl` being present on the standard runner). Push-only via `if`, which cascades to the downstream jobs through `needs` (a skipped dependency skips its dependents), so PRs still run only `checks`.
- **`e2e`** — runs in `mcr.microsoft.com/playwright:v1.59.1-noble`. Browsers and their system deps are prebaked, so the `Install Playwright browsers` step is **gone entirely**. Just installs deps and runs the suite against staging. Uploads the report on failure.
- **`deploy-production`** — unchanged steps, now gated on the `e2e` job succeeding (default `success()` on `needs`).

## Benefits

- No Playwright install on the hot path, and no cache to maintain/evict.
- E2E can be **re-run without redeploying** staging.
- Prod deploy is cleanly gated on a dedicated e2e job.

## Maintenance note

The container tag `v1.59.1-noble` **must stay in sync with `@playwright/test`** in the lockfile (currently `1.59.1`), or browsers won't match. Worth a Renovate/Dependabot rule, or bump it alongside Playwright upgrades.

## Trade-offs vs. the alternative

The other option was a version-keyed `actions/cache` of `~/.cache/ms-playwright` in the single job (smaller change). This container approach was chosen for the cleaner pipeline structure and zero install/cache maintenance, at the cost of a per-run image pull and the tag-sync above.
