### PR TITLE
fix: server pulls client state via sync step 1 on connect (#520)

### DIFF
--- a/packages/workers/src/durable-objects/ProjectDoc.ts
+++ b/packages/workers/src/durable-objects/ProjectDoc.ts
@@ -20,6 +20,10 @@ const messageAwareness = 1;
 interface WebSocketAttachment {
   user: { id: string; [key: string]: unknown };
   awarenessClientId: number | null;
+  // Whether we've sent our own sync step 1 to this connection yet (see
+  // webSocketMessage). Absent/false on connections opened before this field
+  // existed; treated as not-yet-sent.
+  serverSyncStep1Sent?: boolean;
 }
 
 interface SyncRequestBody {
@@ -808,6 +812,26 @@ class ProjectDocBase extends DurableObject<Env> {
   async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
     // Doc may not exist after hibernation wake
     await this.initializeDoc();
+
+    // On the first message from a connection, send our own sync step 1 so the
+    // client answers with a sync step 2 carrying any state we lack. Without this
+    // pull the server only ever learns client state from live `update`
+    // broadcasts, so any change a client made while not actively connected
+    // (offline edits, a reconnect window before the socket was live) is never
+    // synced and is silently lost (#520). The reference y-websocket server sends
+    // sync step 1 on connect; we send it here, on the first inbound message, so
+    // the socket is guaranteed OPEN (the post-acceptWebSocket / pre-101 window
+    // can drop sends -- which is why the proactive sync step 2 alone is not
+    // enough).
+    const firstMsgAttachment = ws.deserializeAttachment() as WebSocketAttachment | null;
+    if (firstMsgAttachment && !firstMsgAttachment.serverSyncStep1Sent) {
+      const syncStep1Encoder = encoding.createEncoder();
+      encoding.writeVarUint(syncStep1Encoder, messageSync);
+      syncProtocol.writeSyncStep1(syncStep1Encoder, this.doc!);
+      this.safeSend(ws, encoding.toUint8Array(syncStep1Encoder));
+      firstMsgAttachment.serverSyncStep1Sent = true;
+      ws.serializeAttachment(firstMsgAttachment);
+    }
 
     try {
       let data: Uint8Array;

--- a/packages/workers/src/durable-objects/__tests__/ProjectDoc.sync-pull.test.ts
+++ b/packages/workers/src/durable-objects/__tests__/ProjectDoc.sync-pull.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression test for the second-client data-loss bug (#520).
+ *
+ * Before the fix, ProjectDoc only ever PUSHED its state to a connecting client
+ * (a proactive sync step 2 plus a sync step 2 reply to the client's sync step
+ * 1). It never sent its own sync step 1, so it had no way to PULL state the
+ * client held but the server lacked -- e.g. a checklist a reviewer created
+ * during a window where the live `update` broadcast was missed. That state was
+ * silently lost: the e2e symptom was the second reviewer's checklist rendering
+ * "Checklist not found".
+ *
+ * The fix makes the server send its own sync step 1 on a connection's first
+ * message, so the client answers with a sync step 2 carrying everything the
+ * server is missing. This test drives that handshake against a real DO and
+ * asserts the server ends up with the client-only checklist.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { env, runInDurableObject } from 'cloudflare:test';
+import * as Y from 'yjs';
+import * as encoding from 'lib0/encoding';
+import * as decoding from 'lib0/decoding';
+import * as syncProtocol from 'y-protocols/sync';
+import { clearProjectDOs } from '../../__tests__/helpers.js';
+import type { ProjectDoc } from '../ProjectDoc.js';
+
+vi.mock('@/auth/config.js', () => ({
+  verifyAuth: vi.fn(async () => ({
+    user: { id: 'user-1', email: 'test@example.com' },
+  })),
+}));
+
+const messageSync = 0;
+
+interface ProjectDocInternals {
+  doc: Y.Doc | null;
+  initializeDoc(): Promise<void>;
+  webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void>;
+}
+
+function toArrayBuffer(u8: Uint8Array): ArrayBuffer {
+  const buf = new ArrayBuffer(u8.byteLength);
+  new Uint8Array(buf).set(u8);
+  return buf;
+}
+
+function makeMockWs(sent: Uint8Array[]): WebSocket {
+  let attachment: unknown = { user: { id: 'user-1' }, awarenessClientId: null };
+  return {
+    readyState: WebSocket.OPEN,
+    send(data: ArrayBuffer | Uint8Array) {
+      sent.push(new Uint8Array(data as ArrayBuffer));
+    },
+    deserializeAttachment: () => attachment,
+    serializeAttachment: (a: unknown) => {
+      attachment = a;
+    },
+    close() {},
+  } as unknown as WebSocket;
+}
+
+/** The first thing y-websocket sends on open: its sync step 1 (state vector). */
+function clientSyncStep1(doc: Y.Doc): ArrayBuffer {
+  const enc = encoding.createEncoder();
+  encoding.writeVarUint(enc, messageSync);
+  syncProtocol.writeSyncStep1(enc, doc);
+  return toArrayBuffer(encoding.toUint8Array(enc));
+}
+
+/** Mirror a real y-websocket client processing one server sync frame, returning any reply. */
+function clientProcess(serverMsg: Uint8Array, clientDoc: Y.Doc): ArrayBuffer | null {
+  const decoder = decoding.createDecoder(serverMsg);
+  if (decoding.readVarUint(decoder) !== messageSync) return null;
+  const enc = encoding.createEncoder();
+  encoding.writeVarUint(enc, messageSync);
+  syncProtocol.readSyncMessage(decoder, enc, clientDoc, 'client');
+  return encoding.length(enc) > 1 ? toArrayBuffer(encoding.toUint8Array(enc)) : null;
+}
+
+describe('ProjectDoc client->server sync pull', () => {
+  const projectId = 'sync-pull-test';
+
+  beforeEach(async () => {
+    await clearProjectDOs([projectId]);
+    vi.clearAllMocks();
+  });
+
+  function getStub() {
+    const id = env.PROJECT_DOC.idFromName(`project:${projectId}`);
+    return env.PROJECT_DOC.get(id);
+  }
+
+  it('pulls a checklist the client has but the server lacks on first message', async () => {
+    const stub = getStub();
+
+    await runInDurableObject(stub, async (instance: ProjectDoc) => {
+      const internals = instance as unknown as ProjectDocInternals;
+      await internals.initializeDoc();
+      const serverDoc = internals.doc!;
+
+      // Server starts with a study and one checklist (cl-a).
+      const seed = new Y.Doc();
+      const seedStudy = new Y.Map<unknown>();
+      seedStudy.set('name', 'Study');
+      const seedChecklists = new Y.Map<unknown>();
+      const clA = new Y.Map<unknown>();
+      clA.set('type', 'AMSTAR2');
+      seedChecklists.set('cl-a', clA);
+      seedStudy.set('checklists', seedChecklists);
+      seed.getMap('reviews').set('study-1', seedStudy);
+      Y.applyUpdate(serverDoc, Y.encodeStateAsUpdate(seed));
+
+      // Client is in sync with the server, then adds cl-b locally -- the write
+      // the server never received via a live broadcast.
+      const clientDoc = new Y.Doc();
+      Y.applyUpdate(clientDoc, Y.encodeStateAsUpdate(serverDoc));
+      const clientChecklists = (clientDoc.getMap('reviews').get('study-1') as Y.Map<unknown>).get(
+        'checklists',
+      ) as Y.Map<unknown>;
+      clientDoc.transact(() => {
+        const clB = new Y.Map<unknown>();
+        clB.set('type', 'AMSTAR2');
+        clientChecklists.set('cl-b', clB);
+      });
+
+      const serverChecklists = () =>
+        (serverDoc.getMap('reviews').get('study-1') as Y.Map<unknown>).get(
+          'checklists',
+        ) as Y.Map<unknown>;
+
+      // Precondition: the server does not have the client's cl-b.
+      expect(serverChecklists().has('cl-b')).toBe(false);
+
+      // Connect: client sends sync step 1 as its first message.
+      const sent: Uint8Array[] = [];
+      const ws = makeMockWs(sent);
+      await internals.webSocketMessage(ws, clientSyncStep1(clientDoc));
+
+      // Feed every server frame back through the client; relay its replies.
+      // With the fix, one of those frames is the server's own sync step 1, to
+      // which the client answers with a sync step 2 containing cl-b.
+      for (const msg of [...sent]) {
+        const reply = clientProcess(msg, clientDoc);
+        if (reply) await internals.webSocketMessage(ws, reply);
+      }
+
+      // The server has now pulled the client-only checklist.
+      expect(serverChecklists().has('cl-b')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The collaboration e2e tests (`concurrent-crdt.spec.ts`) failed intermittently (~1/5) at the load step, before any editing. The failure screenshot was decisive: the second reviewer (Bob) showed **"Checklist not found"**, not "Loading…". Per `ChecklistYjsWrapper`, that means the connection **synced and the render gate opened**, but Bob's checklist was **missing from the document**. So it's data loss of a write, not a handshake hang.

## Root cause

`ProjectDoc` only ever *pushed* its state to a connecting client (a proactive sync step 2, plus a sync step 2 reply to the client's own sync step 1). It sent its own **sync step 1 only on hibernation-wake to already-connected sockets — never to a fresh connection**. So the server had no way to *pull* state a client held but the server lacked.

Client→server sync therefore depended entirely on live `update` broadcasts while connected. Any write made outside a live-connected window (offline edit, a reconnect gap, a missed broadcast) was never pulled and was silently lost. Bob's checklist creation landed in exactly that gap.

The standard y-websocket server and tldraw's sync worker both send sync step 1 on connect — CoRATES had dropped that direction.

## Fix

Send the server's own sync step 1 on a connection's **first inbound message** (so the socket is provably `OPEN` — hibernation-safe; the post-`acceptWebSocket`/pre-101 window can drop sends). The client answers with a sync step 2 carrying anything the server is missing. Restores standard bidirectional sync. ~15 lines, gated by a per-connection attachment flag; Yjs merges are non-destructive so it's low risk.

## Verification

- **Deterministic DO regression test** (`ProjectDoc.sync-pull.test.ts`): drives the handshake against a real `ProjectDoc` and asserts the server pulls a client-only checklist. Fails without the fix, passes with it.
- **Staging e2e**: the three previously-flaky collaboration tests passed **15/15** with retries disabled (5x each). The prior run on a different (disproven) hypothesis failed 1/15 at this exact step.
- Full workers suite (113 tests), typecheck, and lint all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time document syncing so newly received client messages can trigger the server’s sync handshake sooner.
  * Fixed an edge case where server and client changes could drift out of sync, ensuring client-side updates are reliably pulled into the shared document.
* **Tests**
  * Added a regression test covering the document sync flow to prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->