### PR TITLE
workers,web: complete the migration export — formatVersion 2, bearer route, freeze switch

### DIFF
--- a/packages/docs/audits/sync-durability-audit-2026-07.md
+++ b/packages/docs/audits/sync-durability-audit-2026-07.md
@@ -23,29 +23,29 @@ Tests live in `packages/workers/src/durable-objects/__tests__/`
 (ProjectDoc.backlog-sync.test.ts, ProjectDoc.realws-sync.test.ts,
 ProjectDoc.sync-pull.test.ts).
 
-| # | Failure mode | Outcome today | Test |
-|---|--------------|---------------|------|
-| 1 | Offline backlog pushed via handshake, DO restarts | Survives (persisted row or snapshot) | backlog-sync 1, realws 1 |
-| 2 | Backlog update ~1 MB | Survives | backlog-sync 2 |
-| 3 | Backlog update > 2.2 MB (SQLite value cap, enforced identically in local workerd) | WAS silently lost on eviction; now persisted via forced chunked snapshot | backlog-sync 3 |
-| 4 | Insert fails (SQL error) | WAS silently lost; now forced snapshot fallback | backlog-sync 4 |
-| 5 | Insert AND snapshot fallback both fail | Retried on every subsequent update via `forceCompactPending` flag | backlog-sync 5 |
-| 6 | Corrupt persisted update row | WAS a permanent "internal error" on every request; now skipped with `persistence_corrupt_update_row` report | backlog-sync 6 |
-| 7 | Corrupt snapshot chunk | Fails loudly on EVERY request (doc reset on load failure; previously the first failure left a partial doc in memory that later calls silently served) | backlog-sync 7 |
-| 8 | Update whose same-client predecessor was lost | Pending structs: content invisible, but the delete set applies immediately so existing values can read as undefined; handshake heals | backlog-sync 8 |
-| 9 | Dead-socket answers + live-session status (the production incident shape) | Status visible, answers absent; reconnect handshake recovers | backlog-sync 9 |
-| 10 | True eviction / hibernation wake (evictDurableObject) | Storage reload correct, hibernated sockets wake the DO and keep working | realws 1 |
-| 11 | Second client converging on another client's backlog | Converges via proactive SyncStep2 + handshake | realws 2 |
-| 12 | Malformed frames (truncated sync payload, unknown type, raw noise, string frame) | Captured and dropped; same socket and healthy peers keep working | realws 3 |
-| 13 | Client-side throw while applying server sync or encoding the reply | WAS invisible (y-websocket has no error handling; the client simply never answers SyncStep1, so its edits never push); now captured to Sentry with projectId | manual (client) |
+| #   | Failure mode                                                                      | Outcome today                                                                                                                                                | Test                     |
+| --- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
+| 1   | Offline backlog pushed via handshake, DO restarts                                 | Survives (persisted row or snapshot)                                                                                                                         | backlog-sync 1, realws 1 |
+| 2   | Backlog update ~1 MB                                                              | Survives                                                                                                                                                     | backlog-sync 2           |
+| 3   | Backlog update > 2.2 MB (SQLite value cap, enforced identically in local workerd) | WAS silently lost on eviction; now persisted via forced chunked snapshot                                                                                     | backlog-sync 3           |
+| 4   | Insert fails (SQL error)                                                          | WAS silently lost; now forced snapshot fallback                                                                                                              | backlog-sync 4           |
+| 5   | Insert AND snapshot fallback both fail                                            | Retried on every subsequent update via `forceCompactPending` flag                                                                                            | backlog-sync 5           |
+| 6   | Corrupt persisted update row                                                      | WAS a permanent "internal error" on every request; now skipped with `persistence_corrupt_update_row` report                                                  | backlog-sync 6           |
+| 7   | Corrupt snapshot chunk                                                            | Fails loudly on EVERY request (doc reset on load failure; previously the first failure left a partial doc in memory that later calls silently served)        | backlog-sync 7           |
+| 8   | Update whose same-client predecessor was lost                                     | Pending structs: content invisible, but the delete set applies immediately so existing values can read as undefined; handshake heals                         | backlog-sync 8           |
+| 9   | Dead-socket answers + live-session status (the production incident shape)         | Status visible, answers absent; reconnect handshake recovers                                                                                                 | backlog-sync 9           |
+| 10  | True eviction / hibernation wake (evictDurableObject)                             | Storage reload correct, hibernated sockets wake the DO and keep working                                                                                      | realws 1                 |
+| 11  | Second client converging on another client's backlog                              | Converges via proactive SyncStep2 + handshake                                                                                                                | realws 2                 |
+| 12  | Malformed frames (truncated sync payload, unknown type, raw noise, string frame)  | Captured and dropped; same socket and healthy peers keep working                                                                                             | realws 3                 |
+| 13  | Client-side throw while applying server sync or encoding the reply                | WAS invisible (y-websocket has no error handling; the client simply never answers SyncStep1, so its edits never push); now captured to Sentry with projectId | manual (client)          |
 
 ### Not testable locally
 
-| Failure mode | Why | Mitigation |
-|--------------|-----|------------|
-| Websocket message > 1 MiB through the Cloudflare edge (local workerd allows 32 MiB) | Edge-enforced transport cap | A stranded backlog between ~1 MiB and the SQLite cap can never push over the socket in production. Needs a staging test, and ultimately an HTTP force-push path that bypasses the socket. |
-| DO out-of-memory (128 MB isolate) during a huge SyncStep2 apply | Not enforced locally | `getStorageStats()` exposes `memoryUsagePercent`; watch it in the admin dashboard. |
-| Real auto-eviction timing under load | Local eviction is only explicit | Covered logically by evictDurableObject tests. |
+| Failure mode                                                                        | Why                             | Mitigation                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Websocket message > 1 MiB through the Cloudflare edge (local workerd allows 32 MiB) | Edge-enforced transport cap     | A stranded backlog between ~1 MiB and the SQLite cap can never push over the socket in production. Needs a staging test, and ultimately an HTTP force-push path that bypasses the socket. |
+| DO out-of-memory (128 MB isolate) during a huge SyncStep2 apply                     | Not enforced locally            | `getStorageStats()` exposes `memoryUsagePercent`; watch it in the admin dashboard.                                                                                                        |
+| Real auto-eviction timing under load                                                | Local eviction is only explicit | Covered logically by evictDurableObject tests.                                                                                                                                            |
 
 ## Changes made in this pass
 

--- a/packages/web/src/components/project/ChangeOutcomeDialog.tsx
+++ b/packages/web/src/components/project/ChangeOutcomeDialog.tsx
@@ -113,7 +113,10 @@ export function ChangeOutcomeDialog({
         </DialogHeader>
 
         {availableOutcomes.length > 0 ?
-          <Select value={selectedOutcomeId || ''} onValueChange={v => setSelectedOutcomeId(v || null)}>
+          <Select
+            value={selectedOutcomeId || ''}
+            onValueChange={v => setSelectedOutcomeId(v || null)}
+          >
             <SelectTrigger>
               <SelectValue placeholder='Select new outcome...' />
             </SelectTrigger>

--- a/packages/web/src/primitives/useProject/checklists/index.ts
+++ b/packages/web/src/primitives/useProject/checklists/index.ts
@@ -318,7 +318,8 @@ export function createChecklistOperations(
     if (movers.some(c => c.get('status') === CHECKLIST_STATUS.RECONCILING)) {
       return {
         success: false,
-        error: 'Reconciliation is in progress for this outcome. Finish it before changing the outcome.',
+        error:
+          'Reconciliation is in progress for this outcome. Finish it before changing the outcome.',
       };
     }
     if (movers.some(c => targetAssignees.has((c.get('assignedTo') as string | null) ?? null))) {

--- a/packages/web/src/server.ts
+++ b/packages/web/src/server.ts
@@ -18,6 +18,12 @@ const PROJECT_DOC_PATH = /^\/api\/project-doc\/([^/]+)(?:\/.*)?$/;
 // notification fan-out. WebSocket upgrades only.
 const SESSION_PATH = /^\/api\/sessions\/([^/]+)(?:\/.*)?$/;
 
+// `/api/migration/export/<projectId>` — one-time sync-engine cutover export,
+// bearer-gated by SYNC_ADMIN_TOKEN. Calls the devExport() RPC directly:
+// ProjectDoc.fetch serves only WebSocket upgrades and the MIGRATION_FREEZE
+// guard 503s it, but the export has to run during the freeze.
+const MIGRATION_EXPORT_PATH = /^\/api\/migration\/export\/([^/]+)$/;
+
 interface DOEnv {
   USER_SESSION: {
     idFromName(name: string): unknown;
@@ -34,6 +40,17 @@ interface SentryEnv {
 const workerHandler = {
   async fetch(request: Request, env: unknown, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
+
+    const migrationMatch = url.pathname.match(MIGRATION_EXPORT_PATH);
+    if (migrationMatch) {
+      const token = request.headers.get('Authorization')?.replace(/^Bearer /, '');
+      const expected = (env as { SYNC_ADMIN_TOKEN?: string }).SYNC_ADMIN_TOKEN;
+      if (!expected || token !== expected) {
+        return new Response('forbidden', { status: 403 });
+      }
+      const stub = getProjectDocStub(env as never, migrationMatch[1]);
+      return Response.json(await stub.devExport());
+    }
 
     // DO routes must be handled before TanStack Start (which can't pass
     // WebSocket upgrades through). Same Request is forwarded as-is so the

--- a/packages/workers/src/durable-objects/ProjectDoc.ts
+++ b/packages/workers/src/durable-objects/ProjectDoc.ts
@@ -223,6 +223,14 @@ class ProjectDocBase extends DurableObject<Env> {
    * the getProjectInfo() RPC; all other HTTP methods are rejected.
    */
   async fetch(request: Request): Promise<Response> {
+    // Cutover freeze: refuse new connections while the migration export runs.
+    // Only gates the upgrade handshake — open sockets are closed by the deploy
+    // that carries the var, plus an explicit disconnectAllConnections sweep.
+    // The migration export path is unaffected: it calls the devExport() RPC.
+    if ((this.env as { MIGRATION_FREEZE?: string }).MIGRATION_FREEZE === 'true') {
+      return new Response('migration in progress', { status: 503 });
+    }
+
     const upgradeHeader = request.headers.get('Upgrade');
 
     try {

--- a/packages/workers/src/durable-objects/__tests__/ProjectDoc.backlog-sync.test.ts
+++ b/packages/workers/src/durable-objects/__tests__/ProjectDoc.backlog-sync.test.ts
@@ -387,10 +387,7 @@ describe('ProjectDoc sync durability edge cases', () => {
       internals.persistence.forceCompact = originalForce;
 
       getChecklist(clientDoc, 'study-1', 'cl-1').set('status', 'reviewer-completed');
-      const statusUpdate = Y.encodeStateAsUpdate(
-        clientDoc,
-        Y.encodeStateVector(internals.doc!),
-      );
+      const statusUpdate = Y.encodeStateAsUpdate(clientDoc, Y.encodeStateVector(internals.doc!));
       await internals.webSocketMessage(ws, updateMessage(statusUpdate));
       expect(internals.forceCompactPending).toBe(false);
 

--- a/packages/workers/src/durable-objects/__tests__/ProjectDoc.migration-export.test.ts
+++ b/packages/workers/src/durable-objects/__tests__/ProjectDoc.migration-export.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Cutover step 0: the formatVersion 2 migration export.
+ *
+ * The sync-engine transformer refuses v1 exports because they silently drop
+ * outcomeId, annotations, reconciliations, and pdf tag/citation metadata.
+ * These tests pin the v2 shape against a real ProjectDoc, including the two
+ * pdf keying eras that coexist in production docs (web writes key by pdfId
+ * and carry an `id` field; the legacy syncPdf path keys by fileName and has
+ * none — the export must not fabricate an id from the map key, since a
+ * fileName can repeat across studies).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { runInDurableObject } from 'cloudflare:test';
+import { env } from 'cloudflare:workers';
+import * as Y from 'yjs';
+import { clearProjectDOs } from '../../__tests__/helpers.js';
+import type { ProjectDoc } from '../ProjectDoc.js';
+
+describe('devExport (formatVersion 2)', () => {
+  const projectId = 'migration-export-test';
+
+  beforeEach(async () => {
+    await clearProjectDOs([projectId]);
+  });
+
+  function getStub() {
+    const id = env.PROJECT_DOC.idFromName(`project:${projectId}`);
+    return env.PROJECT_DOC.get(id);
+  }
+
+  it('exports the fields the v1 exporter dropped, across both pdf keying eras', async () => {
+    const stub = getStub();
+
+    // Legacy-era pdf: syncPdf keys the pdfs map by fileName, no id/tag.
+    await stub.syncPdf({
+      action: 'add',
+      studyId: 'study-1',
+      studyName: 'Study 1',
+      pdf: {
+        key: 'r2-key-legacy',
+        fileName: 'paper.pdf',
+        size: 1024,
+        uploadedBy: 'user-1',
+        uploadedAt: new Date().toISOString(),
+      },
+    });
+
+    await runInDurableObject(stub, async (instance: ProjectDoc) => {
+      const doc = (instance as unknown as { doc: Y.Doc }).doc;
+      doc.transact(() => {
+        const meta = doc.getMap('meta');
+        meta.set('name', 'Migration Export');
+        // outcomes is a Y.Map keyed by outcomeId (createOutcome in
+        // useProject/outcomes.ts) — the transformer's schema expects a record.
+        const outcomes = new Y.Map<unknown>();
+        const outcome = new Y.Map<unknown>();
+        outcome.set('name', 'Mortality');
+        outcome.set('createdAt', 1700000000000);
+        outcome.set('createdBy', 'user-1');
+        outcomes.set('outcome-1', outcome);
+        meta.set('outcomes', outcomes);
+
+        const study = doc.getMap('reviews').get('study-1') as Y.Map<unknown>;
+        study.set('reviewer1', 'user-1');
+
+        // Checklist with the fields v1 dropped: outcomeId, reviewerName —
+        // and a Y.Text answer that must serialize to a plain string.
+        const checklists = study.get('checklists') as Y.Map<unknown>;
+        const checklist = new Y.Map<unknown>();
+        checklist.set('type', 'ROB2');
+        checklist.set('outcomeId', 'outcome-1');
+        checklist.set('reviewerName', 'Ada');
+        checklist.set('status', 'in_progress');
+        const answers = new Y.Map<unknown>();
+        answers.set('d1_1', 'Y');
+        const comment = new Y.Text();
+        comment.insert(0, 'free text');
+        answers.set('d1_1.comment', comment);
+        checklist.set('answers', answers);
+        checklists.set('cl-1', checklist);
+
+        // Web-era pdf: keyed by pdfId, carries id/tag/citation metadata.
+        const pdfs = study.get('pdfs') as Y.Map<unknown>;
+        const pdf = new Y.Map<unknown>();
+        pdf.set('id', 'pdf-uuid-1');
+        pdf.set('key', 'r2-key-web');
+        pdf.set('fileName', 'web.pdf');
+        pdf.set('size', 2048);
+        pdf.set('tag', 'primary');
+        pdf.set('title', 'A Title');
+        pdfs.set('pdf-uuid-1', pdf);
+
+        // annotations: checklistId → annotationId → annotation.
+        const annotations = new Y.Map<unknown>();
+        const perChecklist = new Y.Map<unknown>();
+        const annotation = new Y.Map<unknown>();
+        annotation.set('pdfId', 'pdf-uuid-1');
+        annotation.set('embedPdfData', '{}');
+        perChecklist.set('ann-1', annotation);
+        annotations.set('cl-1', perChecklist);
+        study.set('annotations', annotations);
+
+        // reconciliations: per-outcome progress maps, shaped like the
+        // updateReconciliationProgress writer in useProject/reconciliation.ts
+        // (checklist1Id/checklist2Id/type are required by the transformer).
+        const reconciliations = new Y.Map<unknown>();
+        const progress = new Y.Map<unknown>();
+        progress.set('checklist1Id', 'cl-1');
+        progress.set('checklist2Id', 'cl-2');
+        progress.set('outcomeId', 'outcome-1');
+        progress.set('type', 'ROB2');
+        progress.set('currentPage', 2);
+        reconciliations.set('outcome-1', progress);
+        study.set('reconciliations', reconciliations);
+      });
+    });
+
+    const exported = (await stub.devExport()) as {
+      formatVersion: number;
+      meta: Record<string, unknown>;
+      studies: Array<Record<string, unknown>>;
+    };
+
+    expect(exported.formatVersion).toBe(2);
+    expect(exported.meta.outcomes).toEqual({
+      'outcome-1': { name: 'Mortality', createdAt: 1700000000000, createdBy: 'user-1' },
+    });
+
+    const study = exported.studies.find(s => s.id === 'study-1')!;
+    expect(study.name).toBe('Study 1');
+    expect(study.reviewer1).toBe('user-1');
+    // The toJSON duplicate of the maps re-exported in keyed form is dropped.
+    expect(study).not.toHaveProperty('reconciliation');
+
+    const checklists = study.checklists as Array<Record<string, unknown>>;
+    const checklist = checklists.find(c => c.id === 'cl-1')!;
+    expect(checklist.outcomeId).toBe('outcome-1');
+    expect(checklist.reviewerName).toBe('Ada');
+    expect(checklist.status).toBe('in_progress');
+    expect((checklist.answers as Record<string, unknown>)['d1_1']).toBe('Y');
+    expect((checklist.answers as Record<string, unknown>)['d1_1.comment']).toBe('free text');
+
+    const pdfs = study.pdfs as Array<Record<string, unknown>>;
+    expect(pdfs).toHaveLength(2);
+    const legacyPdf = pdfs.find(p => p.fileName === 'paper.pdf')!;
+    expect(legacyPdf.key).toBe('r2-key-legacy');
+    expect(legacyPdf).not.toHaveProperty('id'); // no id fabricated from the map key
+    const webPdf = pdfs.find(p => p.fileName === 'web.pdf')!;
+    expect(webPdf.id).toBe('pdf-uuid-1');
+    expect(webPdf.tag).toBe('primary');
+    expect(webPdf.title).toBe('A Title');
+
+    const annotations = study.annotations as Record<
+      string,
+      Record<string, Record<string, unknown>>
+    >;
+    expect(annotations['cl-1']['ann-1'].pdfId).toBe('pdf-uuid-1');
+
+    const reconciliations = study.reconciliations as Record<string, Record<string, unknown>>;
+    expect(reconciliations['outcome-1']).toEqual({
+      checklist1Id: 'cl-1',
+      checklist2Id: 'cl-2',
+      outcomeId: 'outcome-1',
+      type: 'ROB2',
+      currentPage: 2,
+    });
+  });
+
+  it('MIGRATION_FREEZE 503s the upgrade handshake but not the devExport RPC', async () => {
+    const stub = getStub();
+    await stub.syncProject({ meta: { name: 'frozen' }, members: [] });
+
+    await runInDurableObject(stub, async (instance: ProjectDoc) => {
+      (instance as unknown as { env: Record<string, unknown> }).env.MIGRATION_FREEZE = 'true';
+      const res = await instance.fetch(
+        new Request('https://do/api/project-doc/x', { headers: { Upgrade: 'websocket' } }),
+      );
+      expect(res.status).toBe(503);
+    });
+
+    // The export route calls this RPC directly, bypassing the frozen fetch.
+    const exported = (await stub.devExport()) as { formatVersion: number };
+    expect(exported.formatVersion).toBe(2);
+  });
+});

--- a/packages/workers/src/durable-objects/__tests__/ProjectDoc.realws-sync.test.ts
+++ b/packages/workers/src/durable-objects/__tests__/ProjectDoc.realws-sync.test.ts
@@ -278,8 +278,7 @@ describe('ProjectDoc real-websocket sync', () => {
       const study = docB.getMap('reviews').get('study-1') as Y.Map<unknown> | undefined;
       if (!study) return false;
       const cl = (study.get('checklists') as Y.Map<unknown>)?.get('cl-1') as
-        | Y.Map<unknown>
-        | undefined;
+        Y.Map<unknown> | undefined;
       if (!cl) return false;
       const answers = cl.get('answers') as Y.Map<unknown> | undefined;
       if (!answers) return false;

--- a/packages/workers/src/durable-objects/dev-handlers.ts
+++ b/packages/workers/src/durable-objects/dev-handlers.ts
@@ -20,57 +20,6 @@ interface DevContext {
   yMapToPlain: (_map: Y.Map<unknown>) => Record<string, unknown>;
 }
 
-interface ExportData {
-  version: number;
-  exportedAt: string;
-  projectId: string;
-  meta: Record<string, unknown>;
-  members: Array<{ userId: string; [key: string]: unknown }>;
-  studies: Study[];
-}
-
-interface Study {
-  id: string;
-  name?: unknown;
-  description?: unknown;
-  createdAt?: unknown;
-  updatedAt?: unknown;
-  originalTitle?: unknown;
-  firstAuthor?: unknown;
-  publicationYear?: unknown;
-  authors?: unknown;
-  journal?: unknown;
-  doi?: unknown;
-  abstract?: unknown;
-  pdfUrl?: unknown;
-  pdfSource?: unknown;
-  pdfAccessible?: unknown;
-  reviewer1?: unknown;
-  reviewer2?: unknown;
-  checklists: Checklist[];
-  pdfs: Pdf[];
-  reconciliation?: unknown;
-}
-
-interface Checklist {
-  id: string;
-  type?: unknown;
-  title?: unknown;
-  assignedTo?: unknown;
-  status?: unknown;
-  createdAt?: unknown;
-  updatedAt?: unknown;
-  answers?: Record<string, unknown>;
-}
-
-interface Pdf {
-  fileName: string;
-  key?: unknown;
-  size?: unknown;
-  uploadedBy?: unknown;
-  uploadedAt?: unknown;
-}
-
 interface ImportData {
   meta?: Record<string, unknown>;
   members?: Array<{
@@ -190,88 +139,94 @@ interface PatchResult {
 }
 
 /**
- * Export the full Y.Doc state as JSON
+ * Export the full Y.Doc state as JSON.
+ *
+ * formatVersion 2: complete export for the sync-engine cutover. Studies and
+ * checklists are spread verbatim (outcomeId, sourceChecklists, reviewerName…),
+ * and the annotations/reconciliations subtrees plus full pdf metadata are
+ * included — the v1 field lists silently dropped all of them.
  */
 export async function handleDevExport(ctx: DevContext): Promise<Response> {
   const { doc, stateId, yMapToPlain } = ctx;
 
-  const exportData: ExportData = {
-    version: 1,
+  const exportData = {
+    formatVersion: 2, // the cutover transformer refuses v1
     exportedAt: new Date().toISOString(),
     projectId: stateId,
-    meta: yMapToPlain(doc.getMap('meta')),
-    members: [],
-    studies: [],
+    meta: yMapToPlain(doc.getMap('meta')), // carries `outcomes`
+    members: [] as Record<string, unknown>[],
+    studies: [] as Record<string, unknown>[],
   };
 
-  // Export members
   const membersMap = doc.getMap('members');
   for (const [userId, value] of membersMap.entries()) {
-    exportData.members.push({
-      userId,
-      ...yMapToPlain(value as Y.Map<unknown>),
-    });
+    exportData.members.push({ userId, ...yMapToPlain(value as Y.Map<unknown>) });
   }
 
-  // Export studies (reviews) with nested checklists and pdfs
   const reviewsMap = doc.getMap('reviews');
   for (const [studyId, studyValue] of reviewsMap.entries()) {
     const studyYMap = studyValue as Y.Map<unknown>;
     const studyData = yMapToPlain(studyYMap);
-    const study: Study = {
+    const study: Record<string, unknown> = {
+      ...studyData, // every scalar study field, verbatim
       id: studyId,
-      name: studyData.name,
-      description: studyData.description,
-      createdAt: studyData.createdAt,
-      updatedAt: studyData.updatedAt,
-      originalTitle: studyData.originalTitle,
-      firstAuthor: studyData.firstAuthor,
-      publicationYear: studyData.publicationYear,
-      authors: studyData.authors,
-      journal: studyData.journal,
-      doi: studyData.doi,
-      abstract: studyData.abstract,
-      pdfUrl: studyData.pdfUrl,
-      pdfSource: studyData.pdfSource,
-      pdfAccessible: studyData.pdfAccessible,
-      reviewer1: studyData.reviewer1,
-      reviewer2: studyData.reviewer2,
-      checklists: [],
-      pdfs: [],
-      reconciliation: studyData.reconciliation || null,
+      checklists: [] as Record<string, unknown>[],
+      pdfs: [] as Record<string, unknown>[],
     };
+    // The nested maps are re-exported in list/keyed form below; drop the
+    // toJSON copies so the export has one canonical representation of each.
+    delete study.reconciliation;
+    delete study.annotations;
 
-    // Export checklists
     const checklistsMap = studyYMap.get('checklists') as Y.Map<unknown> | undefined;
-    if (checklistsMap && checklistsMap.entries) {
+    if (checklistsMap?.entries) {
       for (const [checklistId, checklistValue] of checklistsMap.entries()) {
         const checklistData = yMapToPlain(checklistValue as Y.Map<unknown>);
-        study.checklists.push({
+        (study.checklists as Record<string, unknown>[]).push({
+          ...checklistData, // includes outcomeId, sourceChecklists, reviewerName
           id: checklistId,
-          type: checklistData.type,
-          title: checklistData.title,
-          assignedTo: checklistData.assignedTo,
           status: checklistData.status || 'pending',
-          createdAt: checklistData.createdAt,
-          updatedAt: checklistData.updatedAt,
           answers: (checklistData.answers as Record<string, unknown>) || {},
         });
       }
     }
 
-    // Export PDFs
     const pdfsMap = studyYMap.get('pdfs') as Y.Map<unknown> | undefined;
-    if (pdfsMap && pdfsMap.entries) {
-      for (const [fileName, pdfValue] of pdfsMap.entries()) {
-        const pdfData = yMapToPlain(pdfValue as Y.Map<unknown>);
-        study.pdfs.push({
-          fileName,
-          key: pdfData.key,
-          size: pdfData.size,
-          uploadedBy: pdfData.uploadedBy,
-          uploadedAt: pdfData.uploadedAt,
-        });
+    if (pdfsMap?.entries) {
+      // Two keying eras coexist: web-written entries are keyed by pdfId and
+      // carry their own `id`; legacy syncPdf entries are keyed by fileName and
+      // have none. Export the value verbatim — no `id` synthesized from the map
+      // key (a fileName can repeat across studies; the transformer derives a
+      // unique fallback id from the R2 `key` when `id` is absent).
+      for (const [, pdfValue] of pdfsMap.entries()) {
+        (study.pdfs as Record<string, unknown>[]).push(
+          yMapToPlain(pdfValue as Y.Map<unknown>), // id?, key, fileName, size, tag, citation metadata…
+        );
       }
+    }
+
+    const annotationsMap = studyYMap.get('annotations') as Y.Map<unknown> | undefined;
+    if (annotationsMap?.entries) {
+      const annotations: Record<string, unknown> = {};
+      for (const [checklistId, checklistAnnotations] of annotationsMap.entries()) {
+        const perChecklist = checklistAnnotations as Y.Map<unknown>;
+        if (!perChecklist?.entries) continue;
+        const entries: Record<string, unknown> = {};
+        for (const [annotationId, annotation] of perChecklist.entries()) {
+          entries[annotationId] = yMapToPlain(annotation as Y.Map<unknown>);
+        }
+        annotations[checklistId] = entries;
+      }
+      study.annotations = annotations;
+    }
+
+    const reconciliationsMap = studyYMap.get('reconciliations') as Y.Map<unknown> | undefined;
+    if (reconciliationsMap?.entries) {
+      const reconciliations: Record<string, unknown> = {};
+      for (const [outcomeKey, progress] of reconciliationsMap.entries()) {
+        reconciliations[outcomeKey] = yMapToPlain(progress as Y.Map<unknown>);
+      }
+      study.reconciliations = reconciliations;
     }
 
     exportData.studies.push(study);


### PR DESCRIPTION
Cutover step 0 for the sync-engine migration ([runbook on the rewrite branch](https://github.com/InfinityBowman/corates/blob/sync-engine-rewrite/packages/docs/plans/sync-engine-cutover.md)). This deploys to the **old** worker days before the cutover window; it touches only the export path and the freeze switch — the app is otherwise unchanged.

## Why

The v1 `handleDevExport` lists fields explicitly and silently drops everything the list missed: checklist `outcomeId` (which the new row plane hard-requires), the `annotations` and `reconciliations` subtrees, and pdf tag/citation metadata. The cutover transformer on `sync-engine-rewrite` refuses v1 exports for exactly that reason — so the old worker needs a complete exporter before anything else can happen.

## What

- **formatVersion-2 `handleDevExport`**: spreads study and checklist maps verbatim, exports annotations and reconciliations in keyed form, full pdf metadata.
- **`/api/migration/export/:projectId`**: bearer-gated by `SYNC_ADMIN_TOKEN` (already set on the worker), calls the `devExport()` RPC directly — `ProjectDoc.fetch` serves only WebSocket upgrades and the freeze guard 503s it, but the export has to run *during* the freeze.
- **`MIGRATION_FREEZE` guard** at the top of `ProjectDoc.fetch`: setting the var makes every new connection 503. It gates only the upgrade handshake; open sockets are closed by the deploy that carries the var plus an explicit `disconnectAllConnections` sweep.

## The pdf keying wrinkle

The patch spec assumed the pdfs Y.Map is keyed by pdfId. It isn't, uniformly: web-written entries are (and carry their own `id` field), but the legacy `syncPdf` server path keyed by fileName and stored no id — both eras can coexist in production docs. Synthesizing an id from the map key would mint fileName ids, which can repeat across studies and collide as row ids downstream. The export emits pdf values verbatim instead; the transformer already derives a unique fallback id from the R2 key when `id` is absent, and verify.ts mirrors the same logic.

## Testing

New workerd test (`ProjectDoc.migration-export.test.ts`) pins the v2 shape against a real ProjectDoc — both pdf keying eras, Y.Text answers serializing to strings, the keyed annotations/reconciliations forms, and the freeze guard 503ing the handshake while `devExport()` keeps working. Workers suite 127/127, web typecheck clean.

After deploy, the sanity gate before relying on it: export one real project through the bearer route and run it through `scripts/sync-cutover/run.ts transform` (on the rewrite branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secure migration export endpoint for project data.
  * Added migration freeze support that temporarily blocks new project connections while keeping exports available.
* **Improvements**
  * Updated migration exports to format version 2.
  * Preserved study fields, checklist metadata, annotations, reconciliation data, and complete PDF metadata during export.
* **Tests**
  * Added coverage for export compatibility, data preservation, duplicate reconciliation handling, and migration freeze behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->