### PR TITLE
Post-cutover fixes: staging e2e dev-panel build, members refetch race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,11 @@ jobs:
           VITE_API_URL: 'https://staging.corates.org'
           VITE_PUBLIC_APP_URL: 'https://staging.corates.org'
           VITE_BASEPATH: '/'
-          VITE_DEV_PANEL: 'false'
+          # The e2e job runs against this deployment and seeds through the
+          # in-page dev seams (window.__devSeed / __devLegacy), which only
+          # exist when the dev panel is compiled in. Staging is a test
+          # environment (DEV_MODE is already true on its worker).
+          VITE_DEV_PANEL: 'true'
           VITE_GOOGLE_PICKER_API_KEY: ${{ vars.VITE_GOOGLE_PICKER_API_KEY }}
           VITE_GOOGLE_PICKER_APP_ID: ${{ vars.VITE_GOOGLE_PICKER_APP_ID }}
         run: pnpm --filter web build

--- a/packages/web/src/project/ConnectionPool.ts
+++ b/packages/web/src/project/ConnectionPool.ts
@@ -201,10 +201,9 @@ class ConnectionPool {
       console.warn('Failed to track sync cache for cleanup:', projectId, err),
     );
 
-    // Membership is D1-authoritative with no live channel of its own; the
-    // workers refresh-disconnect a project's sessions on membership changes,
-    // so a re-sync after having been synced is the poke to refetch members.
-    let hadSynced = false;
+    // Membership is D1-authoritative; the workers refresh-disconnect on
+    // membership changes, so every 'synced' refetches members. No
+    // first-synced gate — the refresh can race the initial connection.
     const applyStatus = (status: string) => {
       if (cancelled()) return;
       const current = useProjectStore.getState().connections[projectId];
@@ -216,10 +215,7 @@ class ConnectionPool {
       else phase = workspace.client.hydrated ? 'cached' : 'connecting';
       useProjectStore.getState().setConnectionState(projectId, phase);
       if (phase === 'synced') {
-        if (hadSynced) {
-          void queryClient.invalidateQueries({ queryKey: queryKeys.projects.members(projectId) });
-        }
-        hadSynced = true;
+        void queryClient.invalidateQueries({ queryKey: queryKeys.projects.members(projectId) });
       }
     };
 


### PR DESCRIPTION
The two follow-ups from the cutover's e2e gate failure.

**ci**: the staging build now compiles the dev panel in, so the e2e job's seeding seams (`window.__devSeed`/`__devLegacy`) exist on staging. This is what made the seeding-dependent specs (realtime-at-scale, persistence-recovery, flat-key-migration) unable to pass against staging.

**web**: members invalidation fires on every `synced` instead of only the second one. The first-synced gate assumed a membership refresh always lands on an already-synced connection; a member added right after project creation refresh-disconnects mid initial connect, the reconnect's `synced` is the first the listener sees, and the invalidation was skipped. Dev's staleTime 0 masked it; production's 5-minute staleTime kept the stale member list until reload (the concurrent-crdt failures).

Verified against staging with this branch deployed: full suite 26 passed / 1 flaky (passed on retry) / 0 failed; the AMSTAR2 spec passes 3/3 solo — remaining flake is parallel-worker contention, not product behavior.

Merging also re-runs the full deploy chain, restoring the client Sentry DSN and picker keys the manual cutover deploy lacked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved membership data synchronization so updates are refreshed reliably during the initial connection and subsequent syncs.
  * Resolved issues where membership changes could remain outdated after synchronization completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->