### PR TITLE
Send appraisal groups back to the To-Do phase from the Reconcile tab

### DIFF
--- a/infra/observability/README.md
+++ b/infra/observability/README.md
@@ -16,6 +16,7 @@ Workers (prod/staging) -> OTLP export -> loki.jacobmaynard.dev/otlp/v1/logs -> L
 - `config/` - Loki config and Grafana datasource provisioning; rsynced to
   `/home/jacob/corates/observability/` on the box by deploy.sh (bind mounts resolve
   remotely when using a docker context)
+- `dashboards/` - Grafana dashboard JSON, imported by hand via Dashboards > New > Import
 - `.env` (gitignored) - R2 S3 credentials, Loki basic-auth htpasswd, Grafana admin password
 - `deploy.sh` - rsync config, then `docker --context homelab compose up -d`
 

--- a/infra/observability/dashboards/corates-logs.json
+++ b/infra/observability/dashboards/corates-logs.json
@@ -1,0 +1,327 @@
+{
+  "title": "CoRATES Logs",
+  "uid": "corates-logs",
+  "description": "Workers logs exported via OTLP to Loki. Structured JSON lines from @corates/shared/logger are parsed with | json. Export latency from Cloudflare is roughly 2-3 minutes.",
+  "tags": ["corates", "loki"],
+  "editable": true,
+  "graphTooltip": 1,
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "loki",
+        "current": {},
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "hide": 0
+      },
+      {
+        "name": "service",
+        "label": "Service",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "${datasource}" },
+        "query": "label_values(service_name)",
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "sort": 1,
+        "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
+        "options": []
+      },
+      {
+        "name": "level",
+        "label": "Level",
+        "type": "custom",
+        "query": "debug,info,warn,error",
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
+        "options": [
+          { "selected": true, "text": "All", "value": "$__all" },
+          { "selected": false, "text": "debug", "value": "debug" },
+          { "selected": false, "text": "info", "value": "info" },
+          { "selected": false, "text": "warn", "value": "warn" },
+          { "selected": false, "text": "error", "value": "error" }
+        ]
+      },
+      {
+        "name": "search",
+        "label": "Search",
+        "type": "textbox",
+        "query": "",
+        "current": { "selected": false, "text": "", "value": "" },
+        "options": []
+      },
+      {
+        "name": "requestId",
+        "label": "Request ID",
+        "type": "textbox",
+        "query": "",
+        "current": { "selected": false, "text": "", "value": "" },
+        "options": []
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Log lines",
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(count_over_time({service_name=~\"$service\"} [$__range]))",
+          "queryType": "instant",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "color": { "mode": "fixed", "fixedColor": "text" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Errors",
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(count_over_time({service_name=~\"$service\"} | json | level=`error` [$__range]))",
+          "queryType": "instant",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "color": { "mode": "fixed", "fixedColor": "#F2495C" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Warnings",
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(count_over_time({service_name=~\"$service\"} | json | level=`warn` [$__range]))",
+          "queryType": "instant",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "color": { "mode": "fixed", "fixedColor": "#FF9830" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Log volume by level",
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "gridPos": { "h": 9, "w": 14, "x": 0, "y": 4 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (level) (count_over_time({service_name=~\"$service\"} | json | level=~`$level` | level=~`.+` [$__auto]))",
+          "legendFormat": "{{level}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 85,
+            "lineWidth": 0,
+            "stacking": { "mode": "normal", "group": "A" },
+            "gradientMode": "none",
+            "showPoints": "never"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "error" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#F2495C" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "warn" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#FF9830" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "info" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#5794F2" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "debug" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#8E8E8E" } }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Warnings and errors by service",
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "gridPos": { "h": 9, "w": 10, "x": 14, "y": 4 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (service_name) (count_over_time({service_name=~\"$service\"} | json | level=~`warn|error` [$__auto]))",
+          "legendFormat": "{{service_name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "corates-workers-prod" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#5794F2" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "corates-workers-staging" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#B877D9" } }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "Top error messages",
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 13 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, sum by (message, service_name) (count_over_time({service_name=~\"$service\"} | json | level=`error` [$__range])))",
+          "queryType": "instant",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": {
+              "message": "Message",
+              "service_name": "Service",
+              "Value": "Count"
+            },
+            "indexByName": { "message": 0, "service_name": 1, "Value": 2 }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "filterable": false } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Count" },
+            "properties": [{ "id": "custom.width", "value": 120 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Service" },
+            "properties": [{ "id": "custom.width", "value": 260 }]
+          }
+        ]
+      },
+      "options": {
+        "sortBy": [{ "displayName": "Count", "desc": true }],
+        "showHeader": true
+      }
+    },
+    {
+      "id": 7,
+      "type": "logs",
+      "title": "Logs",
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "gridPos": { "h": 14, "w": 24, "x": 0, "y": 21 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "{service_name=~\"$service\"} |~ `$search` | json | level=~`$level` | requestId=~`$requestId.*`",
+          "maxLines": 500
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      }
+    }
+  ]
+}

--- a/packages/shared/src/checklists/__tests__/status.test.ts
+++ b/packages/shared/src/checklists/__tests__/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isEditable, getStatusLabel, canTransitionTo } from '../status.js';
+import { isEditable, getStatusLabel } from '../status.js';
 
 describe('Checklist Status', () => {
   describe('isEditable', () => {
@@ -39,51 +39,6 @@ describe('Checklist Status', () => {
 
     it('should return Pending for undefined status', () => {
       expect(getStatusLabel(undefined)).toBe('Pending');
-    });
-  });
-
-  describe('canTransitionTo', () => {
-    it('should allow pending to transition to in-progress', () => {
-      expect(canTransitionTo('pending', 'in-progress')).toBe(true);
-    });
-
-    it('should allow in-progress to transition to reviewer-completed', () => {
-      expect(canTransitionTo('in-progress', 'reviewer-completed')).toBe(true);
-    });
-
-    it('should allow in-progress to transition to finalized', () => {
-      expect(canTransitionTo('in-progress', 'finalized')).toBe(true);
-    });
-
-    it('should allow reconciling to transition to finalized', () => {
-      expect(canTransitionTo('reconciling', 'finalized')).toBe(true);
-    });
-
-    it('should allow finalized to transition back to reconciling', () => {
-      expect(canTransitionTo('finalized', 'reconciling')).toBe(true);
-    });
-
-    it('should not allow finalized to transition anywhere else', () => {
-      expect(canTransitionTo('finalized', 'pending')).toBe(false);
-      expect(canTransitionTo('finalized', 'in-progress')).toBe(false);
-    });
-
-    it('should allow reviewer-completed to transition back to in-progress', () => {
-      expect(canTransitionTo('reviewer-completed', 'in-progress')).toBe(true);
-    });
-
-    it('should not allow reviewer-completed to transition anywhere else', () => {
-      expect(canTransitionTo('reviewer-completed', 'pending')).toBe(false);
-      expect(canTransitionTo('reviewer-completed', 'finalized')).toBe(false);
-    });
-
-    it('should allow staying in the same state', () => {
-      expect(canTransitionTo('pending', 'pending')).toBe(true);
-      expect(canTransitionTo('in-progress', 'in-progress')).toBe(true);
-    });
-
-    it('should not allow skipping states', () => {
-      expect(canTransitionTo('pending', 'finalized')).toBe(false);
     });
   });
 });

--- a/packages/shared/src/checklists/__tests__/status.test.ts
+++ b/packages/shared/src/checklists/__tests__/status.test.ts
@@ -68,8 +68,13 @@ describe('Checklist Status', () => {
       expect(canTransitionTo('finalized', 'in-progress')).toBe(false);
     });
 
-    it('should not allow reviewer-completed to transition', () => {
-      expect(canTransitionTo('reviewer-completed', 'in-progress')).toBe(false);
+    it('should allow reviewer-completed to transition back to in-progress', () => {
+      expect(canTransitionTo('reviewer-completed', 'in-progress')).toBe(true);
+    });
+
+    it('should not allow reviewer-completed to transition anywhere else', () => {
+      expect(canTransitionTo('reviewer-completed', 'pending')).toBe(false);
+      expect(canTransitionTo('reviewer-completed', 'finalized')).toBe(false);
     });
 
     it('should allow staying in the same state', () => {

--- a/packages/shared/src/checklists/domain.ts
+++ b/packages/shared/src/checklists/domain.ts
@@ -434,6 +434,51 @@ export function getReopenableReconciledChecklist(
 }
 
 /**
+ * Describes what sending an outcome group back to the todo phase would do:
+ * which reviewer checklists become editable again, and which consensus
+ * checklist (if reconciliation was already started) gets discarded.
+ */
+export interface SendBackToTodoPlan {
+  reviewerChecklists: StudyChecklist[];
+  reconciledChecklist: StudyChecklist | null;
+}
+
+/**
+ * Builds the plan for sending an outcome group back to the todo phase, or
+ * returns null when the action does not apply.
+ *
+ * Mirrors the `checklist.sendBackToTodo` mutator's guards so the UI only
+ * offers the action when the server would accept it: a group whose
+ * reconciliation is already finalized must be reopened from the Completed tab
+ * instead.
+ *
+ * @param study - The study object
+ * @param outcomeId - The outcome ID (null for AMSTAR2)
+ * @param type - The checklist type
+ * @returns The plan, or null if the group cannot be sent back
+ */
+export function getSendBackToTodoPlan(
+  study: Study | null | undefined,
+  outcomeId: string | null,
+  type: string,
+): SendBackToTodoPlan | null {
+  if (!study) return null;
+
+  const checklists = study.checklists || [];
+  const inGroup = checklists.filter(c => c.type === type && (c.outcomeId ?? null) === outcomeId);
+
+  const reviewerChecklists = inGroup.filter(
+    c => !isReconciledChecklist(c) && c.status === CHECKLIST_STATUS.REVIEWER_COMPLETED,
+  );
+  if (reviewerChecklists.length === 0) return null;
+
+  const reconciledChecklists = inGroup.filter(isReconciledChecklist);
+  if (reconciledChecklists.some(c => c.status === CHECKLIST_STATUS.FINALIZED)) return null;
+
+  return { reviewerChecklists, reconciledChecklist: reconciledChecklists[0] ?? null };
+}
+
+/**
  * Groups completed checklists by outcome
  */
 export function getCompletedChecklistsByOutcome(study: Study | null | undefined): ChecklistGroup[] {

--- a/packages/shared/src/checklists/status.ts
+++ b/packages/shared/src/checklists/status.ts
@@ -51,60 +51,6 @@ export function getStatusLabel(status: ChecklistStatus | string | undefined): st
 }
 
 /**
- * Validates if a status transition is allowed
- * @param currentStatus - The current status
- * @param newStatus - The desired new status
- * @returns True if the transition is valid
- */
-export function canTransitionTo(
-  currentStatus: ChecklistStatus | string,
-  newStatus: ChecklistStatus | string,
-): boolean {
-  // Can always stay in the same state
-  if (currentStatus === newStatus) return true;
-
-  // Can transition from pending to in-progress (automatic on first edit)
-  if (currentStatus === CHECKLIST_STATUS.PENDING && newStatus === CHECKLIST_STATUS.IN_PROGRESS) {
-    return true;
-  }
-
-  // Can transition from in-progress to reviewer-completed or finalized
-  if (currentStatus === CHECKLIST_STATUS.IN_PROGRESS) {
-    return (
-      newStatus === CHECKLIST_STATUS.REVIEWER_COMPLETED || newStatus === CHECKLIST_STATUS.FINALIZED
-    );
-  }
-
-  // Can transition from reconciling to finalized (after reconciliation is complete)
-  if (currentStatus === CHECKLIST_STATUS.RECONCILING && newStatus === CHECKLIST_STATUS.FINALIZED) {
-    return true;
-  }
-
-  // Can reopen a finalized reconciled checklist back into reconciliation
-  if (currentStatus === CHECKLIST_STATUS.FINALIZED && newStatus === CHECKLIST_STATUS.RECONCILING) {
-    return true;
-  }
-
-  // Can send a reviewer checklist awaiting reconciliation back to the todo phase
-  if (
-    currentStatus === CHECKLIST_STATUS.REVIEWER_COMPLETED &&
-    newStatus === CHECKLIST_STATUS.IN_PROGRESS
-  ) {
-    return true;
-  }
-
-  // Cannot otherwise transition from finalized or reviewer-completed (locked)
-  if (
-    currentStatus === CHECKLIST_STATUS.FINALIZED ||
-    currentStatus === CHECKLIST_STATUS.REVIEWER_COMPLETED
-  ) {
-    return false;
-  }
-
-  return false;
-}
-
-/**
  * Gets Tailwind CSS classes for status badge styling.
  * Note: This is UI-specific but kept here for convenience.
  * Consider moving to web package if shared package should be pure logic.

--- a/packages/shared/src/checklists/status.ts
+++ b/packages/shared/src/checklists/status.ts
@@ -85,6 +85,14 @@ export function canTransitionTo(
     return true;
   }
 
+  // Can send a reviewer checklist awaiting reconciliation back to the todo phase
+  if (
+    currentStatus === CHECKLIST_STATUS.REVIEWER_COMPLETED &&
+    newStatus === CHECKLIST_STATUS.IN_PROGRESS
+  ) {
+    return true;
+  }
+
   // Cannot otherwise transition from finalized or reviewer-completed (locked)
   if (
     currentStatus === CHECKLIST_STATUS.FINALIZED ||

--- a/packages/shared/src/sync/__tests__/checklists.test.ts
+++ b/packages/shared/src/sync/__tests__/checklists.test.ts
@@ -636,3 +636,211 @@ describe('checklist.delete', () => {
     ).toBeUndefined();
   });
 });
+
+describe('checklist.sendBackToTodo', () => {
+  function seedPair(
+    engine: Engine,
+    status: 'reviewer-completed' | 'in-progress' = 'reviewer-completed',
+  ) {
+    seedStudy(engine);
+    for (const [id, assignedTo] of [
+      ['chk-1', 'user-1'],
+      ['chk-2', 'user-2'],
+    ] as const) {
+      engine.mutate('checklist.create', {
+        id,
+        studyId: 'study-1',
+        type: 'AMSTAR2',
+        assignedTo,
+        outcomeId: null,
+        now: NOW,
+      });
+      engine.mutate('checklist.update', { checklistId: id, updates: { status }, now: NOW });
+    }
+  }
+
+  function seedConsensus(engine: Engine, status: 'reconciling' | 'finalized' = 'reconciling') {
+    engine.mutate('checklist.create', {
+      id: 'chk-consensus',
+      studyId: 'study-1',
+      type: 'AMSTAR2',
+      assignedTo: null,
+      outcomeId: null,
+      now: NOW,
+    });
+    engine.mutate('checklist.update', {
+      checklistId: 'chk-consensus',
+      updates: { status },
+      now: NOW,
+    });
+    engine.mutate('reconciliation.saveProgress', {
+      studyId: 'study-1',
+      outcomeId: null,
+      type: 'AMSTAR2',
+      data: {
+        checklist1Id: 'chk-1',
+        checklist2Id: 'chk-2',
+        reconciledChecklistId: 'chk-consensus',
+      },
+      now: NOW,
+    });
+  }
+
+  it('returns both reviewer checklists to in-progress and drops the progress row', () => {
+    const engine = newEngine();
+    seedPair(engine);
+    engine.mutate('reconciliation.saveProgress', {
+      studyId: 'study-1',
+      outcomeId: null,
+      type: 'AMSTAR2',
+      data: { checklist1Id: 'chk-1', checklist2Id: 'chk-2' },
+      now: NOW,
+    });
+
+    const result = engine.mutate('checklist.sendBackToTodo', {
+      studyId: 'study-1',
+      outcomeId: null,
+      type: 'AMSTAR2',
+      now: LATER,
+    });
+    expect(result.error).toBeUndefined();
+
+    expect(engine.get('checklists', 'chk-1')).toMatchObject({
+      status: 'in-progress',
+      updatedAt: LATER,
+    });
+    expect(engine.get('checklists', 'chk-2')?.status).toBe('in-progress');
+    expect(
+      engine.get('reconciliations', reconciliationRowId('study-1', 'type:AMSTAR2')),
+    ).toBeNull();
+    expect(engine.get('studies', 'study-1')?.updatedAt).toBe(LATER);
+  });
+
+  it('discards the in-progress consensus checklist and its answer rows', () => {
+    const engine = newEngine();
+    seedPair(engine);
+    seedConsensus(engine);
+    expect(answersFor(engine, 'chk-consensus').size).toBeGreaterThan(0);
+
+    const result = engine.mutate('checklist.sendBackToTodo', {
+      studyId: 'study-1',
+      outcomeId: null,
+      type: 'AMSTAR2',
+      now: LATER,
+    });
+    expect(result.error).toBeUndefined();
+
+    expect(engine.get('checklists', 'chk-consensus')).toBeNull();
+    expect(answersFor(engine, 'chk-consensus').size).toBe(0);
+    // The reviewers' own answers survive: they are what becomes editable again.
+    expect(answersFor(engine, 'chk-1').size).toBeGreaterThan(0);
+  });
+
+  it('reverts a lone completed reviewer, leaving the partner mid-appraisal untouched', () => {
+    const engine = newEngine();
+    seedPair(engine);
+    engine.mutate('checklist.update', {
+      checklistId: 'chk-2',
+      updates: { status: 'in-progress' },
+      now: NOW,
+    });
+
+    const result = engine.mutate('checklist.sendBackToTodo', {
+      studyId: 'study-1',
+      outcomeId: null,
+      type: 'AMSTAR2',
+      now: LATER,
+    });
+    expect(result.error).toBeUndefined();
+
+    expect(engine.get('checklists', 'chk-1')).toMatchObject({
+      status: 'in-progress',
+      updatedAt: LATER,
+    });
+    expect(engine.get('checklists', 'chk-2')?.updatedAt).toBe(NOW);
+  });
+
+  it('rejects a group whose reconciliation is already finalized', () => {
+    const engine = newEngine();
+    seedPair(engine);
+    seedConsensus(engine, 'finalized');
+
+    const result = engine.mutate('checklist.sendBackToTodo', {
+      studyId: 'study-1',
+      outcomeId: null,
+      type: 'AMSTAR2',
+      now: LATER,
+    });
+    expect(result.error?.code).toBe('ReconciliationFinalized');
+    expect(engine.get('checklists', 'chk-1')?.status).toBe('reviewer-completed');
+    expect(engine.get('checklists', 'chk-consensus')).not.toBeNull();
+  });
+
+  it('guards: unknown study, and a group with nothing awaiting reconciliation', () => {
+    const engine = newEngine();
+    seedPair(engine, 'in-progress');
+
+    expect(
+      engine.mutate('checklist.sendBackToTodo', {
+        studyId: 'study-missing',
+        outcomeId: null,
+        type: 'AMSTAR2',
+        now: LATER,
+      }).error?.code,
+    ).toBe('NotFound');
+    expect(
+      engine.mutate('checklist.sendBackToTodo', {
+        studyId: 'study-1',
+        outcomeId: null,
+        type: 'AMSTAR2',
+        now: LATER,
+      }).error?.code,
+    ).toBe('NotFound');
+  });
+
+  it('only touches the addressed outcome group', () => {
+    const engine = newEngine();
+    seedStudy(engine);
+    for (const outcomeId of ['out-1', 'out-2']) {
+      engine.mutate('outcome.create', {
+        id: outcomeId,
+        name: outcomeId,
+        createdBy: 'user-1',
+        now: NOW,
+      });
+    }
+    for (const [id, assignedTo, outcomeId] of [
+      ['chk-1', 'user-1', 'out-1'],
+      ['chk-2', 'user-2', 'out-1'],
+      ['chk-3', 'user-1', 'out-2'],
+      ['chk-4', 'user-2', 'out-2'],
+    ] as const) {
+      engine.mutate('checklist.create', {
+        id,
+        studyId: 'study-1',
+        type: 'ROBINS_I',
+        assignedTo,
+        outcomeId,
+        now: NOW,
+      });
+      engine.mutate('checklist.update', {
+        checklistId: id,
+        updates: { status: 'reviewer-completed' },
+        now: NOW,
+      });
+    }
+
+    const result = engine.mutate('checklist.sendBackToTodo', {
+      studyId: 'study-1',
+      outcomeId: 'out-1',
+      type: 'ROBINS_I',
+      now: LATER,
+    });
+    expect(result.error).toBeUndefined();
+
+    expect(engine.get('checklists', 'chk-1')?.status).toBe('in-progress');
+    expect(engine.get('checklists', 'chk-2')?.status).toBe('in-progress');
+    expect(engine.get('checklists', 'chk-3')?.status).toBe('reviewer-completed');
+    expect(engine.get('checklists', 'chk-4')?.status).toBe('reviewer-completed');
+  });
+});

--- a/packages/shared/src/sync/mutators.ts
+++ b/packages/shared/src/sync/mutators.ts
@@ -415,6 +415,74 @@ export const syncMutators = defineMutators(
       },
     },
 
+    /**
+     * Return an outcome group's reviewer checklists to the To-Do phase.
+     *
+     * The consensus checklist is discarded rather than kept: it is derived from
+     * the very answers that are about to become editable again, so preserving
+     * it would leave a third checklist whose contents no longer correspond to
+     * either reviewer. Reopening an already-finalized reconciliation is the
+     * Completed tab's job (`getReopenableReconciledChecklist`), so a finalized
+     * group is rejected here instead of being silently thrown away.
+     */
+    'checklist.sendBackToTodo': {
+      args: z.object({
+        studyId: z.string(),
+        outcomeId: z.string().nullable(),
+        type: CHECKLIST_TYPE,
+        now: timestamp,
+      }),
+      apply: (tx, { studyId, outcomeId, type, now }, ctx) => {
+        assertWritable(ctx);
+        const study = tx.get('studies', studyId);
+        if (!study) throw new AppError('NotFound', `Study ${studyId} does not exist`);
+
+        const reviewerChecklists = [];
+        // Concurrent opens can transiently leave more than one consensus
+        // checklist for a group, so collect them all rather than the first.
+        const reconciledChecklists = [];
+        for (const row of tx.list('checklists')) {
+          const checklist = row.data;
+          if (checklist.studyId !== studyId || checklist.type !== type) continue;
+          if (checklist.outcomeId !== outcomeId) continue;
+          if (checklist.assignedTo === null) reconciledChecklists.push(checklist);
+          else if (checklist.status === CHECKLIST_STATUS.REVIEWER_COMPLETED) {
+            reviewerChecklists.push(checklist);
+          }
+        }
+
+        if (reviewerChecklists.length === 0) {
+          throw new AppError(
+            'NotFound',
+            'No reviewer checklists are awaiting reconciliation for this outcome',
+          );
+        }
+        if (reconciledChecklists.some(c => c.status === CHECKLIST_STATUS.FINALIZED)) {
+          throw new AppError(
+            'ReconciliationFinalized',
+            'This outcome is already reconciled. Reopen it from the Completed tab first.',
+          );
+        }
+
+        for (const checklist of reviewerChecklists) {
+          tx.put('checklists', checklist.id, {
+            ...checklist,
+            status: CHECKLIST_STATUS.IN_PROGRESS,
+            updatedAt: now,
+          });
+        }
+
+        for (const reconciled of reconciledChecklists) {
+          tx.del('checklists', reconciled.id);
+          deleteAnswerRows(tx, reconciled.id);
+        }
+
+        tx.del('reconciliations', reconciliationRowId(studyId, getOutcomeKey(outcomeId, type)));
+
+        tx.put('studies', studyId, { ...study, updatedAt: now });
+      },
+    },
+
     'checklist.updateAnswer': {
       args: z.object({
         checklistId: z.string(),

--- a/packages/web/e2e/send-back-to-todo.spec.ts
+++ b/packages/web/e2e/send-back-to-todo.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * E2E Test: Send an appraisal group back to the To-Do phase
+ *
+ * Covers both entry points on the Reconcile tab -- a group still waiting on the
+ * second reviewer, and a ready pair whose reconciliation has already started
+ * (where the consensus checklist is discarded) -- plus the guard that bounces a
+ * reviewer who is sitting on the reconciliation screen when it happens.
+ *
+ * Prerequisites:
+ *   pnpm --filter web dev  (localhost:3010, DEV_MODE=true)
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import {
+  seedDualReviewerScenario,
+  cleanupScenario,
+  switchUser,
+  loginAs,
+  type DualReviewerScenario,
+} from './helpers';
+import { setupProjectWithStudy, markChecklistComplete, answerAllAMSTAR2 } from './shared-steps';
+import { BASE_URL } from './constants';
+
+let scenario: DualReviewerScenario;
+
+test.beforeAll(async () => {
+  scenario = await seedDualReviewerScenario();
+});
+
+test.afterAll(async () => {
+  if (scenario) await cleanupScenario(scenario);
+});
+
+/** Add an AMSTAR2 checklist, answer every question, and mark it complete. */
+async function addAndCompleteChecklist(page: Page, projectId: string, answer: 'Yes' | 'No') {
+  await page.getByRole('tab', { name: /To Do/i }).click();
+  await expect(page.getByRole('button', { name: /Select Checklist/i })).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await page.getByRole('button', { name: /Select Checklist/i }).click();
+  await page.getByRole('button', { name: /Add Checklist/i }).click();
+  await expect(page.getByRole('button', { name: 'Open', exact: true })).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.getByRole('button', { name: 'Open', exact: true }).last().click();
+  await expect(page).toHaveURL(/\/checklists\//, { timeout: 10_000 });
+
+  // Another reviewer's checklist may sort first; fall back to the other row.
+  if (
+    await page
+      .getByText('Read-only')
+      .isVisible()
+      .catch(() => false)
+  ) {
+    await page.goBack();
+    await page.getByRole('button', { name: 'Open', exact: true }).first().click();
+    await expect(page).toHaveURL(/\/checklists\//, { timeout: 10_000 });
+  }
+
+  await answerAllAMSTAR2(page, answer);
+  await markChecklistComplete(page);
+  await page.goto(`/projects/${projectId}`);
+  await expect(page.getByRole('tab', { name: /To Do/i })).toBeVisible({ timeout: 15_000 });
+}
+
+/** Click Send Back on the first reconcile row and confirm the dialog. */
+async function sendBackFirstGroup(page: Page, expectsConsensusWarning: boolean) {
+  await page.getByRole('button', { name: 'Send Back', exact: true }).first().click();
+
+  const dialog = page.getByRole('alertdialog');
+  await expect(dialog.getByText('Send Back to To-Do')).toBeVisible({ timeout: 5_000 });
+  if (expectsConsensusWarning) {
+    await expect(dialog.getByText(/consensus checklist/i)).toBeVisible();
+  } else {
+    await expect(dialog.getByText(/consensus checklist/i)).toBeHidden();
+  }
+
+  await dialog.getByRole('button', { name: 'Send Back', exact: true }).click();
+  await expect(dialog).toBeHidden({ timeout: 10_000 });
+}
+
+const RECONCILE_EMPTY_STATE = /Studies where reviewers have completed their checklists/i;
+
+test('Send appraisals back to To-Do from the Reconcile tab', async ({ browser, context, page }) => {
+  const projectId = await setupProjectWithStudy(context, page, scenario, 'Send Back E2E');
+
+  // ================================================================
+  // Waiting group: one reviewer done, no reconciliation started
+  // ================================================================
+  await addAndCompleteChecklist(page, projectId, 'Yes');
+
+  await page.getByRole('tab', { name: /Reconcile/i }).click();
+  await expect(page.getByText(/Waiting for/i)).toBeVisible({ timeout: 10_000 });
+
+  await sendBackFirstGroup(page, false);
+
+  await expect(page.getByText(RECONCILE_EMPTY_STATE)).toBeVisible({ timeout: 10_000 });
+
+  // The checklist is editable again rather than locked
+  await page.getByRole('tab', { name: /To Do/i }).click();
+  await page.getByRole('button', { name: 'Open', exact: true }).first().click();
+  await expect(page).toHaveURL(/\/checklists\//, { timeout: 10_000 });
+  await expect(page.getByRole('button', { name: /Mark Complete/i })).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Re-complete it so the pair can become ready
+  await markChecklistComplete(page);
+  await page.goto(`/projects/${projectId}`);
+  await expect(page.getByRole('tab', { name: /To Do/i })).toBeVisible({ timeout: 15_000 });
+
+  // ================================================================
+  // Ready pair: second reviewer completes, then opens reconciliation
+  // ================================================================
+  await switchUser(context, scenario.cookiesB);
+  await page.goto(`/projects/${projectId}`);
+  await expect(page.getByText('Send Back E2E').first()).toBeVisible({ timeout: 15_000 });
+
+  await addAndCompleteChecklist(page, projectId, 'No');
+
+  await page.getByRole('tab', { name: /Reconcile/i }).click();
+  await expect(page.getByText('Ready')).toBeVisible({ timeout: 10_000 });
+
+  // Opening the screen creates the consensus checklist; user B stays on it
+  await page.getByRole('button', { name: /^Reconcile$/ }).click();
+  await expect(page).toHaveURL(/\/reconcile\//, { timeout: 10_000 });
+  await expect(page.getByText('Setting up reconciliation...')).toBeHidden({ timeout: 20_000 });
+
+  // ================================================================
+  // User A sends the group back while user B watches the reconciliation
+  // ================================================================
+  const contextA = await browser.newContext();
+  const pageA = await contextA.newPage();
+  await loginAs(contextA, scenario.cookiesA);
+
+  try {
+    // Land on the dashboard first so the fresh context resolves its active org
+    // before hitting a project-scoped route.
+    await pageA.goto(`${BASE_URL}/dashboard`);
+    await expect(pageA.getByText('Welcome back,')).toBeVisible({ timeout: 15_000 });
+
+    await pageA.goto(`${BASE_URL}/projects/${projectId}`);
+    await pageA.getByRole('tab', { name: /Reconcile/i }).click();
+    await expect(pageA.getByText('Ready')).toBeVisible({ timeout: 15_000 });
+
+    await sendBackFirstGroup(pageA, true);
+
+    await expect(pageA.getByText(RECONCILE_EMPTY_STATE)).toBeVisible({ timeout: 10_000 });
+
+    // User B is pushed off the now-meaningless reconciliation screen
+    await expect(page).toHaveURL(/\/projects\/[^/]+\?tab=todo/, { timeout: 20_000 });
+    await expect(page.getByText('Reconciliation Cancelled')).toBeVisible({ timeout: 10_000 });
+
+    // Both reviewers have the appraisal back, and nothing was finalized
+    await expect(page.getByRole('button', { name: 'Open', exact: true }).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await pageA.getByRole('tab', { name: /To Do/i }).click();
+    await expect(pageA.getByRole('button', { name: 'Open', exact: true }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await pageA.getByRole('tab', { name: /Completed/i }).click();
+    await expect(pageA.getByText(/Studies that have completed reconciliation/i)).toBeVisible({
+      timeout: 10_000,
+    });
+  } finally {
+    await contextA.close();
+  }
+});

--- a/packages/web/src/components/project/reconcile-tab/ReconcileStudyRow.tsx
+++ b/packages/web/src/components/project/reconcile-tab/ReconcileStudyRow.tsx
@@ -13,12 +13,15 @@ import {
   CHECKLIST_STATUS,
   isReconciledChecklist,
   getReconciliationChecklistsByOutcome,
+  getSendBackToTodoPlan,
 } from '@corates/shared/checklists';
 import type { ChecklistGroup } from '@corates/shared/checklists';
 import { getChecklistMetadata } from '@/checklist-registry';
 import { PdfListItem } from '@/components/pdf/PdfListItem';
+import { project } from '@/project';
 import { ChangeOutcomeDialog } from '../ChangeOutcomeDialog';
 import { ReconcileStatusTag } from './ReconcileStatusTag';
+import { SendBackToTodoButton } from './SendBackToTodoButton';
 import type { StudyInfo, PdfEntry } from '@/stores/projectStore';
 
 interface ReconcileStudyRowProps {
@@ -84,6 +87,18 @@ export function ReconcileStudyRow({
     },
     [onReconcile],
   );
+
+  const renderSendBack = (group: ChecklistGroup | null) => {
+    if (!group) return null;
+    const plan = getSendBackToTodoPlan(study, group.outcomeId, group.type);
+    if (!plan) return null;
+    return (
+      <SendBackToTodoButton
+        discardsReconciliation={!!plan.reconciledChecklist}
+        onSendBack={() => project.checklist.sendBackToTodo(study.id, group.type, group.outcomeId)}
+      />
+    );
+  };
 
   const handleRowClick = useCallback(
     (e: React.MouseEvent) => {
@@ -162,6 +177,8 @@ export function ReconcileStudyRow({
                 </div>
               )}
 
+              {renderSendBack(firstReadyGroup || waitingGroups[0] || null)}
+
               <Button
                 onClick={e => {
                   e.stopPropagation();
@@ -227,10 +244,13 @@ export function ReconcileStudyRow({
                           {getReviewerName(group.checklists[1])}
                         </span>
                       </div>
-                      <Button onClick={() => startReconciliation(group)}>
-                        <GitCompareArrowsIcon className='size-4' />
-                        Reconcile
-                      </Button>
+                      <div className='flex items-center gap-2'>
+                        {renderSendBack(group)}
+                        <Button onClick={() => startReconciliation(group)}>
+                          <GitCompareArrowsIcon className='size-4' />
+                          Reconcile
+                        </Button>
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -273,9 +293,12 @@ export function ReconcileStudyRow({
                           {getReviewerName(group.checklists[0])} -- waiting for second reviewer
                         </span>
                       </div>
-                      <span className='bg-secondary text-muted-foreground shrink-0 rounded-lg px-3 py-1.5 text-sm font-medium'>
-                        Waiting
-                      </span>
+                      <div className='flex items-center gap-2'>
+                        {renderSendBack(group)}
+                        <span className='bg-secondary text-muted-foreground shrink-0 rounded-lg px-3 py-1.5 text-sm font-medium'>
+                          Waiting
+                        </span>
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/packages/web/src/components/project/reconcile-tab/ReconciliationWrapper.tsx
+++ b/packages/web/src/components/project/reconcile-tab/ReconciliationWrapper.tsx
@@ -416,6 +416,31 @@ export function ReconciliationWrapper({
     saveReconciliationProgress,
   ]);
 
+  // Someone else can send this outcome group back to To-Do while we are on the
+  // page, which un-completes the reviewer checklists and deletes the consensus
+  // checklist under us. The race-recovery effect above cannot help — it adopts
+  // a surviving reconciled checklist, and here none survives — so the latched
+  // id would point at a deleted row and the engine would render against it.
+  useEffect(() => {
+    if (
+      !currentStudy ||
+      (connectionState.phase !== 'synced' && connectionState.phase !== 'cached')
+    ) {
+      return;
+    }
+
+    const stillAwaiting = [checklist1Meta, checklist2Meta].every(
+      meta => meta?.status === CHECKLIST_STATUS.REVIEWER_COMPLETED,
+    );
+    if (stillAwaiting) return;
+
+    showToast.info(
+      'Reconciliation Cancelled',
+      "This appraisal was sent back to the reviewers' To-Do lists.",
+    );
+    navigate({ to: `/projects/${projectId}?tab=todo` as string, replace: true });
+  }, [currentStudy, connectionState.phase, checklist1Meta, checklist2Meta, navigate, projectId]);
+
   // Get reconciled checklist metadata
   const reconciledChecklistMeta = useMemo(() => {
     if (!currentStudy || !reconciledChecklistId) return null;

--- a/packages/web/src/components/project/reconcile-tab/SendBackToTodoButton.tsx
+++ b/packages/web/src/components/project/reconcile-tab/SendBackToTodoButton.tsx
@@ -1,0 +1,66 @@
+/**
+ * SendBackToTodoButton - Confirmation-gated action that returns an outcome
+ * group's reviewer checklists to the To-Do phase. Any consensus checklist that
+ * reconciliation already produced is discarded, so the copy changes to say so.
+ */
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogIcon,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface SendBackToTodoButtonProps {
+  onSendBack: () => void;
+  discardsReconciliation: boolean;
+}
+
+export function SendBackToTodoButton({
+  onSendBack,
+  discardsReconciliation,
+}: SendBackToTodoButtonProps) {
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant='secondary'
+        onClick={e => {
+          e.stopPropagation();
+          setShowConfirm(true);
+        }}
+      >
+        Send Back
+      </Button>
+
+      <AlertDialog open={showConfirm} onOpenChange={setShowConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogIcon variant='warning' />
+            <div>
+              <AlertDialogTitle>Send Back to To-Do</AlertDialogTitle>
+              <AlertDialogDescription>
+                Each reviewer gets this appraisal back in their To-Do list and can edit their
+                answers again.
+                {discardsReconciliation &&
+                  ' The consensus checklist started for this outcome, and all answers on it, will be permanently deleted.'}
+              </AlertDialogDescription>
+            </div>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={onSendBack}>Send Back</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/packages/web/src/lib/__tests__/checklist-domain.test.ts
+++ b/packages/web/src/lib/__tests__/checklist-domain.test.ts
@@ -21,6 +21,7 @@ import {
   getReconciliationChecklistsByOutcome,
   getReadyReconciliationPairs,
   getReopenableReconciledChecklist,
+  getSendBackToTodoPlan,
   CHECKLIST_STATUS,
 } from '@corates/shared/checklists';
 
@@ -779,6 +780,114 @@ describe('checklist-domain', () => {
       expect(result?.id).toBe('cl-reconciled-1');
       // outcome-2 has a finalized reconciled checklist but no reviewer pair
       expect(getReopenableReconciledChecklist(study, 'outcome-2', 'ROB2')).toBe(null);
+    });
+  });
+
+  describe('getSendBackToTodoPlan', () => {
+    const awaitingPair = () => [
+      createChecklist({
+        id: 'cl-1',
+        assignedTo: 'user-1',
+        status: CHECKLIST_STATUS.REVIEWER_COMPLETED,
+      }),
+      createChecklist({
+        id: 'cl-2',
+        assignedTo: 'user-2',
+        status: CHECKLIST_STATUS.REVIEWER_COMPLETED,
+      }),
+    ];
+
+    it('plans both reviewer checklists when no reconciliation was started', () => {
+      const study = createStudy({ reviewer2: 'user-2', checklists: awaitingPair() });
+      const plan = getSendBackToTodoPlan(study, null, 'AMSTAR2');
+      expect(plan?.reviewerChecklists.map(c => c.id)).toEqual(['cl-1', 'cl-2']);
+      expect(plan?.reconciledChecklist).toBe(null);
+    });
+
+    it('includes the in-progress consensus checklist that would be discarded', () => {
+      const study = createStudy({
+        reviewer2: 'user-2',
+        checklists: [
+          ...awaitingPair(),
+          createChecklist({
+            id: 'cl-reconciled',
+            assignedTo: null,
+            status: CHECKLIST_STATUS.RECONCILING,
+          }),
+        ],
+      });
+      const plan = getSendBackToTodoPlan(study, null, 'AMSTAR2');
+      expect(plan?.reconciledChecklist?.id).toBe('cl-reconciled');
+    });
+
+    it('plans a single reviewer still waiting on their partner', () => {
+      const study = createStudy({
+        reviewer2: 'user-2',
+        checklists: [
+          awaitingPair()[0],
+          createChecklist({
+            id: 'cl-2',
+            assignedTo: 'user-2',
+            status: CHECKLIST_STATUS.IN_PROGRESS,
+          }),
+        ],
+      });
+      const plan = getSendBackToTodoPlan(study, null, 'AMSTAR2');
+      expect(plan?.reviewerChecklists.map(c => c.id)).toEqual(['cl-1']);
+    });
+
+    it('returns null when nothing is awaiting reconciliation', () => {
+      const study = createStudy({
+        reviewer2: 'user-2',
+        checklists: [
+          createChecklist({ id: 'cl-1', status: CHECKLIST_STATUS.IN_PROGRESS }),
+          createChecklist({
+            id: 'cl-2',
+            assignedTo: 'user-2',
+            status: CHECKLIST_STATUS.IN_PROGRESS,
+          }),
+        ],
+      });
+      expect(getSendBackToTodoPlan(study, null, 'AMSTAR2')).toBe(null);
+    });
+
+    it('returns null once the group is reconciled -- Reopen owns that state', () => {
+      const study = createStudy({
+        reviewer2: 'user-2',
+        checklists: [
+          ...awaitingPair(),
+          createChecklist({
+            id: 'cl-reconciled',
+            assignedTo: null,
+            status: CHECKLIST_STATUS.FINALIZED,
+          }),
+        ],
+      });
+      expect(getSendBackToTodoPlan(study, null, 'AMSTAR2')).toBe(null);
+    });
+
+    it('scopes to the requested outcome for outcome-based types', () => {
+      const study = createStudy({
+        reviewer2: 'user-2',
+        checklists: [
+          createChecklist({
+            id: 'cl-1',
+            type: 'ROB2',
+            outcomeId: 'outcome-1',
+            assignedTo: 'user-1',
+            status: CHECKLIST_STATUS.REVIEWER_COMPLETED,
+          }),
+          createChecklist({
+            id: 'cl-2',
+            type: 'ROB2',
+            outcomeId: 'outcome-2',
+            assignedTo: 'user-2',
+            status: CHECKLIST_STATUS.REVIEWER_COMPLETED,
+          }),
+        ],
+      });
+      expect(getSendBackToTodoPlan(study, 'outcome-1', 'ROB2')?.reviewerChecklists).toHaveLength(1);
+      expect(getSendBackToTodoPlan(study, 'outcome-3', 'ROB2')).toBe(null);
     });
   });
 });

--- a/packages/web/src/project/actions.ts
+++ b/packages/web/src/project/actions.ts
@@ -80,6 +80,19 @@ export const project = {
       return true;
     },
 
+    sendBackToTodo(studyId: string, type: string, outcomeId: string | null): boolean {
+      const client = requireClient();
+      void client.mutate.checklist.sendBackToTodo({
+        studyId,
+        outcomeId,
+        type: type as 'AMSTAR2' | 'ROB2' | 'ROBINS_I',
+        now: Date.now(),
+      });
+      track('Checklist:SentBackToTodo', { type });
+      showToast.success('Sent Back', "The appraisal is back in the reviewers' To-Do lists.");
+      return true;
+    },
+
     update(_studyId: string, checklistId: string, updates: Record<string, unknown>): void {
       const client = requireClient();
       void client.mutate.checklist.update({


### PR DESCRIPTION
Either reviewer can now return an appraisal group that is awaiting reconciliation to the To-Do phase, where both reviewers can edit their answers again. If reconciliation had already started, the third (consensus) checklist is discarded.

## How it works

`checklist.sendBackToTodo` is a single shared mutator, so the same guards run optimistically on the client and authoritatively on the server:

- reviewer checklists in the outcome group go back to `in-progress`
- any non-finalized consensus checklist is deleted along with its answer rows
- the group's `reconciliations` row is dropped
- the study is touched

It rejects a group whose reconciliation is already **finalized** — that state belongs to the Completed tab's existing Reopen action — and a group with nothing awaiting reconciliation. It collects every consensus row rather than the first, since a concurrent reconcile-open can transiently leave two.

`getSendBackToTodoPlan` mirrors those guards for UI gating and tells the confirmation dialog whether a consensus checklist would be destroyed.

## UI

A confirmation-gated **Send Back** button on all three Reconcile tab spots: single-outcome inline, each multi-outcome READY row, and each WAITING row (a reviewer who completed prematurely previously had no way back). The dialog adds an explicit warning that the consensus checklist and its answers will be permanently deleted when reconciliation has already started.

## Concurrency guard

`ReconciliationWrapper` now bounces a reviewer who is sitting on the reconciliation screen when someone else sends the group back. Without it the latched `reconciledChecklistId` outlives the deleted row: the existing race-recovery effect only adopts a *surviving* consensus checklist, and here none survives, so the loading gate passes and the engine renders against a missing checklist.

## Decisions

| Question | Choice |
| --- | --- |
| Granularity | Per outcome group, matching Reconcile / Change Outcome / Reopen |
| Waiting groups | Included — a reviewer who completes by mistake can undo it |
| Permissions | Any project member, matching the ungated Reopen precedent |
| Already-reopened consensus | Allowed, with explicit warning about the deletion |

## Drive-by cleanup

Second commit deletes `canTransitionTo` from `shared/checklists/status.ts`. It had no callers outside its own tests, so it documented transitions without gating any of them while needing an edit for every workflow change (this feature would have been the third). The mutator guards in `sync/mutators.ts` are the real enforcement and are now the only place the checklist state machine lives.

## Notes

- The mutator mirrors `checklist.delete` in not clearing annotation rows. In practice the consensus checklist has none: the reconcile engine has no annotation path.

## Test plan

- [x] `pnpm --filter @corates/shared test` — 267 passed, incl. 6 new mutator tests (ready pair, consensus discard, lone-reviewer revert, finalized rejection, guards, group scoping)
- [x] `pnpm --filter web test` — 328 passed, incl. 6 new domain tests
- [x] New e2e `send-back-to-todo.spec.ts` — waiting-group path, ready pair with reconciliation started, and the two-context guard
- [x] `amstar2-workflow` and `change-outcome` e2e still pass
- [x] `pnpm lint`, `pnpm format`, `pnpm typecheck` clean