### PR TITLE
workers,web: make logging Loki-first and correlate requests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -361,6 +361,7 @@ export default [
       'reference/**',
       '**/.localflare/**',
       '.claude/skills/**/examples/**',
+      '.claude/worktrees/**',
       'packages/ai/**',
       '**/worker-configuration.d.ts',
     ],

--- a/infra/observability/README.md
+++ b/infra/observability/README.md
@@ -5,7 +5,7 @@ chunks stored in the `corates-loki` R2 bucket. Cloudflare Workers Observability 
 OTLP JSON logs directly to Loki's native OTLP endpoint - no collector or tail worker.
 
 ```
-Workers (prod/staging) -> OTLP export -> loki.jacobmaynard.dev/otlp/v1/logs -> Loki -> R2
+Workers (production) -> OTLP export -> loki.jacobmaynard.dev/otlp/v1/logs -> Loki -> R2
                                                      Grafana (grafana.jacobmaynard.dev) queries Loki
 ```
 
@@ -37,13 +37,15 @@ Grafana talks to Loki internally over the docker network without auth.
 - Workers Observability > destinations: type Logs, endpoint
   `https://loki.jacobmaynard.dev/otlp/v1/logs`, header `Authorization: Basic <see .env>`
 - Worker configs reference the destination by name in `observability.logs.destinations`
-  (see `packages/web/wrangler.jsonc` and `packages/stripe-purchases/wrangler.jsonc`)
+  (see `packages/web/wrangler.jsonc` and `packages/stripe-purchases/wrangler.jsonc`).
+  Only the `production` envs export; staging logs stay in Cloudflare Workers Logs so the
+  Grafana views are production-only.
 - Retention is 90d (`limits_config.retention_period` in `config/loki/loki-config.yaml`)
 
 ## Useful LogQL
 
 ```logql
-{service_name="corates-workers-prod"}                          # all prod logs
-{service_name=~"corates-workers.*"} |= "error"                 # errors, both envs
+{service_name="corates-workers-prod"}                          # all web worker logs
+{service_name=~"corates-.*"} |= "error"                        # errors across services
 {service_name="corates-workers-prod"} | json | level="warn"    # structured fields
 ```

--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -77,6 +77,7 @@ export default withMermaid({
               { text: 'Testing', link: '/guides/testing' },
               { text: 'Development Workflow', link: '/guides/development-workflow' },
               { text: 'Error Handling', link: '/guides/error-handling' },
+              { text: 'Observability', link: '/guides/observability' },
               { text: 'Style Guide', link: '/guides/style-guide' },
               { text: 'Glossary', link: '/glossary' },
             ],

--- a/packages/docs/guides/index.md
+++ b/packages/docs/guides/index.md
@@ -24,4 +24,5 @@ Practical guides for common development tasks and patterns in CoRATES.
 - [Testing](/guides/testing) - Testing philosophy, patterns, and best practices for frontend and backend
 - [Development Workflow](/guides/development-workflow) - Getting started, development commands, and common tasks
 - [Error Handling](/guides/error-handling) - How to handle errors consistently across the application
+- [Observability](/guides/observability) - Structured logging, request correlation, Loki queries, and Sentry
 - [Style Guide](/guides/style-guide) - UI/UX guidelines and design system

--- a/packages/docs/guides/observability.md
+++ b/packages/docs/guides/observability.md
@@ -13,14 +13,16 @@ Informational logs are not mirrored into Sentry. Loki already holds 100% of them
 copy would be duplicated volume against a separately metered quota.
 
 ```
-Workers (prod/staging) -> OTLP -> loki.jacobmaynard.dev -> Loki -> R2 (corates-loki)
+Workers (production) -> OTLP -> loki.jacobmaynard.dev -> Loki -> R2 (corates-loki)
                                           Grafana queries Loki
 
 Exceptions (all envs with a DSN) -> Sentry
 ```
 
-Staging deliberately has **no `SENTRY_DSN`**. Loki is the only signal there, which is why the
-structured fields below matter.
+Only production exports to Loki. Staging keeps `persist: true`, so its logs stay in Cloudflare
+Workers Logs (shorter retention, queried in the dashboard or with `wrangler tail`) and never
+mix into the Grafana views. Staging also deliberately has **no `SENTRY_DSN`**, so Workers Logs
+is the only staging signal - the structured fields below are what make it searchable there too.
 
 ## The entry shape
 

--- a/packages/docs/guides/observability.md
+++ b/packages/docs/guides/observability.md
@@ -1,0 +1,159 @@
+# Observability Guide
+
+How CoRATES emits, ships, and queries logs, and where Sentry fits.
+
+## Overview
+
+Logging is **Loki-first**. Every server-side log is a single line of structured JSON on the
+console; Cloudflare Workers Observability exports those lines over OTLP to a self-hosted Loki,
+where they are queryable for 90 days. Sentry is reserved for **exceptions** - places where a
+stack trace, release mapping, and (in the browser) a session replay are worth having.
+
+Informational logs are not mirrored into Sentry. Loki already holds 100% of them, so a second
+copy would be duplicated volume against a separately metered quota.
+
+```
+Workers (prod/staging) -> OTLP -> loki.jacobmaynard.dev -> Loki -> R2 (corates-loki)
+                                          Grafana queries Loki
+
+Exceptions (all envs with a DSN) -> Sentry
+```
+
+Staging deliberately has **no `SENTRY_DSN`**. Loki is the only signal there, which is why the
+structured fields below matter.
+
+## The entry shape
+
+`createLogger()` in `@corates/shared/logger` is the single primitive. Every entry is one JSON
+object so Loki can parse it with `| json` and turn each key into a queryable field:
+
+```json
+{
+  "ts": "2026-08-08T22:14:03.219Z",
+  "level": "info",
+  "service": "corates-workers",
+  "env": "production",
+  "requestId": "3f2b...",
+  "cfRay": "8e1c...",
+  "message": "Created personal org org_123 for user usr_456",
+  "route": "/api/projects",
+  "method": "POST",
+  "userId": "usr_456"
+}
+```
+
+`ts`, `level`, `service`, and `message` are always present. `env`, `requestId`, and `cfRay` come
+from the request scope; anything else is per-call data or scope context.
+
+## Which logger to use
+
+| Package            | Import                         | Notes                                                                                    |
+| ------------------ | ------------------------------ | ---------------------------------------------------------------------------------------- |
+| `workers`          | `@corates/workers/logger`      | `debug` / `info` / `warn` / `captureError`. The default for all server code.             |
+| `stripe-purchases` | `src/lib/observability/logger` | Hono-request-scoped wrapper adding `.stripe(action, data)` with a typed field whitelist. |
+| `web` (server)     | `@corates/workers/logger`      | Same as workers - server functions, route handlers, middleware.                          |
+| `web` (browser)    | `@/config/sentry`              | No Loki path exists from the browser; use `captureException`.                            |
+
+Only reach for `createLogger` directly when you need a distinct `service` name, as the web
+Stripe webhook route does.
+
+## Request correlation
+
+Every log emitted while handling a request carries the same `requestId`, so one query returns
+the whole story of a failure.
+
+The scope is opened in `packages/web/src/server.ts`, which reads an inbound `x-request-id`
+(falling back to a fresh UUID) and captures `cf-ray`, `env`, `route`, and `method`. It is
+carried by `AsyncLocalStorage` rather than a threaded parameter, which is why command
+signatures stay `(env, actor, params)` while their logs still correlate.
+
+`authMiddleware` narrows the scope with `userId` once the caller is known, so anything
+downstream of auth logs the user too.
+
+```js
+import { runWithLogger, runWithContext, getRequestId } from '@corates/workers/logger';
+
+// Entry points open a scope
+runWithLogger({ requestId, cfRay, env, context: { route, method } }, () => handler());
+
+// Middleware narrows one
+runWithContext({ userId }, () => next());
+
+// Anything else reads the current id
+const id = getRequestId();
+```
+
+### Crossing into a Durable Object
+
+`AsyncLocalStorage` does not survive `stub.fetch()` - the DO runs in its own isolate. The id
+therefore travels as an `x-request-id` header, and the DO reopens a scope from it:
+
+```js
+// Caller (packages/web/src/server.ts)
+const headers = new Headers(request.headers);
+headers.set('x-request-id', requestId);
+return stub.fetch(new Request(request, { headers }));
+
+// Callee (UserSession.fetch)
+runWithLogger({ requestId: request.headers.get('x-request-id') ?? crypto.randomUUID() }, ...);
+```
+
+Rebuilding the Request this way preserves the WebSocket upgrade handshake, which is pinned by
+`durable-objects/__tests__/do-correlation.test.ts` - the same test also asserts the ALS scope
+does _not_ cross, since that is the whole reason the header exists.
+
+Two things still log unscoped:
+
+- **`WorkspaceDO`** (the sync engine). Its stub forwarding happens inside `@cf-sync/server`,
+  so propagating an id there needs a change in that package. It emits no CoRATES logs today.
+- **Module-init and test code**, which has no request to attach to.
+
+Hibernated WebSocket callbacks (`webSocketMessage`, `webSocketError`) also fall outside: they
+fire long after the originating request, so there is no scope left to inherit.
+
+## Levels
+
+- `debug` - diagnostic detail, not expected to be read routinely
+- `info` - a thing happened that you would want to see when reconstructing a request
+- `warn` - degraded but handled; the operation still succeeded
+- `error` - the operation failed. Prefer `captureError`, which logs _and_ reports to Sentry.
+
+Printf-style call sites are supported and interpolated into `message` so log queries read
+naturally:
+
+```js
+info('Created personal org %s for user %s', [orgId, userId]);
+```
+
+## Sentry
+
+| Surface        | Wiring                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Browser        | `packages/web/src/config/sentry.ts` - replay (masked text, blocked media), feedback widget, TanStack Router tracing |
+| Web Worker     | `packages/web/src/server.ts` - `Sentry.withSentry` over `fetch` + `queue`                                           |
+| Durable Object | `packages/workers/src/durable-objects/UserSession.ts` - `instrumentDurableObjectWithSentry`                         |
+| Stripe worker  | `packages/stripe-purchases/src/index.ts` - `Sentry.withSentry`                                                      |
+| Sourcemaps     | `sentryVitePlugin` in `packages/web/vite.config.ts`                                                                 |
+
+Every browser-side helper no-ops without a DSN, so local development stays quiet.
+
+In the browser, the rule of thumb is **error means capture, warn means console**. A failure the
+user attempted and that did not complete gets `captureException` with `component` and `action`
+tags. A tolerated degradation - a metadata lookup that fell back, a cache write that missed -
+stays a `console.warn` and rides along as a Sentry breadcrumb if a real error follows.
+
+The Worker entries do not set `enableLogs`; nothing calls `Sentry.logger.*`.
+
+## Querying
+
+Grafana lives at `grafana.jacobmaynard.dev` with one dashboard, `CoRATES Logs`.
+
+```logql
+{service_name="corates-workers-prod"}                          # all prod logs
+{service_name=~"corates-workers.*"} |= "error"                 # errors, both envs
+{service_name="corates-workers-prod"} | json | level="warn"    # structured fields
+{service_name="corates-workers-prod"} | json | requestId="3f2b..."   # one request
+```
+
+Retention is 90 days (`limits_config.retention_period`). Deploying and operating the stack
+itself is covered in `infra/observability/README.md`.

--- a/packages/docs/guides/observability.md
+++ b/packages/docs/guides/observability.md
@@ -47,12 +47,13 @@ from the request scope; anything else is per-call data or scope context.
 
 ## Which logger to use
 
-| Package            | Import                         | Notes                                                                                    |
-| ------------------ | ------------------------------ | ---------------------------------------------------------------------------------------- |
-| `workers`          | `@corates/workers/logger`      | `debug` / `info` / `warn` / `captureError`. The default for all server code.             |
-| `stripe-purchases` | `src/lib/observability/logger` | Hono-request-scoped wrapper adding `.stripe(action, data)` with a typed field whitelist. |
-| `web` (server)     | `@corates/workers/logger`      | Same as workers - server functions, route handlers, middleware.                          |
-| `web` (browser)    | `@/config/sentry`              | No Loki path exists from the browser; use `captureException`.                            |
+| Package            | Import                          | Notes                                                                                    |
+| ------------------ | ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `workers`          | `@corates/workers/logger`       | `debug` / `info` / `warn` / `captureError`. The default for all server code.             |
+| sync engine        | `createWorkspaceDO({ logger })` | Engine diagnostics; the hook in `sync/workspace.ts` forwards them to the same logger.    |
+| `stripe-purchases` | `src/lib/observability/logger`  | Hono-request-scoped wrapper adding `.stripe(action, data)` with a typed field whitelist. |
+| `web` (server)     | `@corates/workers/logger`       | Same as workers - server functions, route handlers, middleware.                          |
+| `web` (browser)    | `@/config/sentry`               | No Loki path exists from the browser; use `captureException`.                            |
 
 Only reach for `createLogger` directly when you need a distinct `service` name, as the web
 Stripe webhook route does.
@@ -102,10 +103,18 @@ Rebuilding the Request this way preserves the WebSocket upgrade handshake, which
 `durable-objects/__tests__/do-correlation.test.ts` - the same test also asserts the ALS scope
 does _not_ cross, since that is the whole reason the header exists.
 
+`UserSession` logs also carry `requestIdForwarded`, which separates an entry that joins back
+to a worker request from one holding only a locally minted id - both are UUIDs, so they are
+otherwise indistinguishable.
+
 Two things still log unscoped:
 
-- **`WorkspaceDO`** (the sync engine). Its stub forwarding happens inside `@cf-sync/server`,
-  so propagating an id there needs a change in that package. It emits no CoRATES logs today.
+- **`WorkspaceDO`** (the sync engine). `createWorkspaceDO` takes a `logger`, which
+  `sync/workspace.ts` supplies, so the engine's init failures, schema-drift warnings and
+  internal errors go through the shared logger and reach Loki as structured JSON. They carry
+  no `requestId` though: the DO class comes from `@cf-sync/server`, so there is no `fetch` of
+  ours to open a scope in. (The sync route does forward all original request headers, so the
+  missing piece is scope, not transport.)
 - **Module-init and test code**, which has no request to attach to.
 
 Hibernated WebSocket callbacks (`webSocketMessage`, `webSocketError`) also fall outside: they

--- a/packages/docs/guides/observability.md
+++ b/packages/docs/guides/observability.md
@@ -111,10 +111,11 @@ Two things still log unscoped:
 
 - **`WorkspaceDO`** (the sync engine). `createWorkspaceDO` takes a `logger`, which
   `sync/workspace.ts` supplies, so the engine's init failures, schema-drift warnings and
-  internal errors go through the shared logger and reach Loki as structured JSON. They carry
-  no `requestId` though: the DO class comes from `@cf-sync/server`, so there is no `fetch` of
-  ours to open a scope in. (The sync route does forward all original request headers, so the
-  missing piece is scope, not transport.)
+  internal errors go through the shared logger and reach Loki as structured JSON. These join
+  on `projectId`, not `requestId` - the engine stamps every diagnostic with the workspace it
+  came from (`@cf-sync/server` 0.2.0), and a workspace id _is_ a projectId here. A requestId
+  would be meaningless on them: init failures fire at DO construction and internal errors on
+  a live socket, both outside any request.
 - **Module-init and test code**, which has no request to attach to.
 
 Hibernated WebSocket callbacks (`webSocketMessage`, `webSocketError`) also fall outside: they

--- a/packages/docs/guides/observability.md
+++ b/packages/docs/guides/observability.md
@@ -51,7 +51,7 @@ from the request scope; anything else is per-call data or scope context.
 
 | Package            | Import                          | Notes                                                                                    |
 | ------------------ | ------------------------------- | ---------------------------------------------------------------------------------------- |
-| `workers`          | `@corates/workers/logger`       | `debug` / `info` / `warn` / `captureError`. The default for all server code.             |
+| `workers`          | `@corates/workers/logger`       | `info` / `warn` / `captureError`. The default for all server code.                       |
 | sync engine        | `createWorkspaceDO({ logger })` | Engine diagnostics; the hook in `sync/workspace.ts` forwards them to the same logger.    |
 | `stripe-purchases` | `src/lib/observability/logger`  | Hono-request-scoped wrapper adding `.stripe(action, data)` with a typed field whitelist. |
 | `web` (server)     | `@corates/workers/logger`       | Same as workers - server functions, route handlers, middleware.                          |
@@ -65,10 +65,15 @@ Stripe webhook route does.
 Every log emitted while handling a request carries the same `requestId`, so one query returns
 the whole story of a failure.
 
-The scope is opened in `packages/web/src/server.ts`, which reads an inbound `x-request-id`
-(falling back to a fresh UUID) and captures `cf-ray`, `env`, `route`, and `method`. It is
-carried by `AsyncLocalStorage` rather than a threaded parameter, which is why command
-signatures stay `(env, actor, params)` while their logs still correlate.
+The scope is opened in `packages/web/src/server.ts`, which captures `cf-ray`, `env`, `route`,
+and `method`. It is carried by `AsyncLocalStorage` rather than a threaded parameter, which is
+why command signatures stay `(env, actor, params)` while their logs still correlate.
+
+The id itself comes from an inbound `x-request-id` when there is one, so a caller's id survives
+across hops - but only if it matches `^[A-Za-z0-9_-]{1,64}$`, otherwise a fresh UUID is minted.
+The header is attacker-controlled on a public worker: a client that sends one fixed value
+collapses correlation for everything it touches, and a multi-kilobyte value would be copied
+into every log line of the request and shipped onward.
 
 `authMiddleware` narrows the scope with `userId` once the caller is known, so anything
 downstream of auth logs the user too.
@@ -125,7 +130,6 @@ fire long after the originating request, so there is no scope left to inherit.
 
 ## Levels
 
-- `debug` - diagnostic detail, not expected to be read routinely
 - `info` - a thing happened that you would want to see when reconstructing a request
 - `warn` - degraded but handled; the operation still succeeded
 - `error` - the operation failed. Prefer `captureError`, which logs _and_ reports to Sentry.
@@ -154,6 +158,11 @@ user attempted and that did not complete gets `captureException` with `component
 tags. A tolerated degradation - a metadata lookup that fell back, a cache write that missed -
 stays a `console.warn` and rides along as a Sentry breadcrumb if a real error follows.
 
+`bestEffort` in `@/lib/errorLogger` follows the same split: it warns by default and only reports
+when the call site passes `capture: true`. IndexedDB cache writes fail routinely under Safari
+private browsing and quota pressure, so they stay on the console; the rollback deletes do pass
+it, because a rollback that did not run leaves an orphaned object in R2.
+
 The Worker entries do not set `enableLogs`; nothing calls `Sentry.logger.*`.
 
 ## Querying
@@ -161,8 +170,8 @@ The Worker entries do not set `enableLogs`; nothing calls `Sentry.logger.*`.
 Grafana lives at `grafana.jacobmaynard.dev` with one dashboard, `CoRATES Logs`.
 
 ```logql
-{service_name="corates-workers-prod"}                          # all prod logs
-{service_name=~"corates-workers.*"} |= "error"                 # errors, both envs
+{service_name="corates-workers-prod"}                          # all web worker logs
+{service_name=~"corates-.*"} |= "error"                        # errors across services
 {service_name="corates-workers-prod"} | json | level="warn"    # structured fields
 {service_name="corates-workers-prod"} | json | requestId="3f2b..."   # one request
 ```

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -75,7 +75,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
-    "@cf-sync/server": "^0.1.0",
+    "@cf-sync/server": "^0.2.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   },

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -36,8 +36,6 @@ export interface LoggerOptions {
   cfRay?: string | null;
   /** Static fields merged into every entry (e.g. route, method, component) */
   context?: Record<string, unknown>;
-  /** Extra sink invoked with each entry (e.g. Sentry log forwarding) */
-  onEntry?: (entry: LogEntry) => void;
 }
 
 const consoleFor: Record<LogLevelType, (line: string) => void> = {
@@ -48,7 +46,7 @@ const consoleFor: Record<LogLevelType, (line: string) => void> = {
 };
 
 export function createLogger(options: LoggerOptions): Logger {
-  const { service, env, requestId, cfRay, context, onEntry } = options;
+  const { service, env, requestId, cfRay, context } = options;
 
   function emit(level: LogLevelType, message: string, data?: Record<string, unknown>): LogEntry {
     const entry: LogEntry = {
@@ -63,7 +61,6 @@ export function createLogger(options: LoggerOptions): Logger {
       ...data,
     };
     consoleFor[level](JSON.stringify(entry));
-    onEntry?.(entry);
     return entry;
   }
 

--- a/packages/stripe-purchases/src/index.ts
+++ b/packages/stripe-purchases/src/index.ts
@@ -25,7 +25,6 @@ export default Sentry.withSentry(
     enabled: !!env.SENTRY_DSN,
     tracesSampleRate: env.ENVIRONMENT === 'production' ? 0.1 : 1.0,
     sendDefaultPii: true,
-    enableLogs: true,
   }),
   app,
 );

--- a/packages/stripe-purchases/wrangler.jsonc
+++ b/packages/stripe-purchases/wrangler.jsonc
@@ -137,8 +137,7 @@
           "enabled": true,
           "head_sampling_rate": 1,
           "persist": true,
-          "invocation_logs": true,
-          "destinations": ["corates-loki"]
+          "invocation_logs": true
         }
       }
     }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@ark-ui/react": "^5.38.1",
     "@cf-sync/client": "^0.1.0",
-    "@cf-sync/yjs": "^0.1.0",
+    "@cf-sync/yjs": "^0.2.0",
     "@corates/db": "workspace:*",
     "@corates/shared": "workspace:*",
     "@corates/workers": "workspace:*",
@@ -104,7 +104,7 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
-    "@cf-sync/server": "^0.1.0",
+    "@cf-sync/server": "^0.2.0",
     "@cloudflare/vite-plugin": "^1.51.1",
     "@cloudflare/vitest-pool-workers": "^0.20.3",
     "@cloudflare/workers-types": "^5.20260808.1",

--- a/packages/web/src/components/pdf/embedpdf/react/src/components/print-dialog.tsx
+++ b/packages/web/src/components/pdf/embedpdf/react/src/components/print-dialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { usePrint } from '@embedpdf/plugin-print/react';
 import { useScroll } from '@embedpdf/plugin-scroll/react';
 import type { PdfPrintOptions } from '@embedpdf/models';
+import { captureException } from '@/config/sentry';
 import { Dialog, DialogContent, DialogFooter, Button } from './ui';
 
 type PageSelection = 'all' | 'current' | 'custom';
@@ -65,12 +66,14 @@ export function PrintDialog({ documentId, isOpen, onClose }: PrintDialogProps) {
           },
           error => {
             console.error('Print failed:', error);
+            captureException(error, { component: 'PrintDialog', action: 'print.task' });
             setIsLoading(false);
           },
         );
       }
     } catch (err) {
       console.error('Print failed:', err);
+      captureException(err, { component: 'PrintDialog', action: 'print' });
       setIsLoading(false);
     }
   };

--- a/packages/web/src/components/pdf/embedpdf/react/src/viewer.tsx
+++ b/packages/web/src/components/pdf/embedpdf/react/src/viewer.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState, useEffect } from 'react';
 import { EmbedPDF } from '@embedpdf/core/react';
 import { usePdfiumEngine } from '@embedpdf/engines/react';
 import { PDFIUM_WASM_URL } from '@/lib/pdfiumWasmUrl';
+import { captureException } from '@/config/sentry';
 import { createPluginRegistration } from '@embedpdf/core';
 import { ViewportPluginPackage, Viewport } from '@embedpdf/plugin-viewport/react';
 import { ScrollPluginPackage, ScrollStrategy, Scroller } from '@embedpdf/plugin-scroll/react';
@@ -160,6 +161,11 @@ function AnnotationSyncManager({
         console.log('[AnnotationSync] importAnnotations completed');
       } catch (err) {
         console.error('[AnnotationSync] Failed to import annotations:', err);
+        captureException(err, {
+          component: 'EmbedPdfViewer',
+          action: 'importAnnotations',
+          count: importItems.length,
+        });
       } finally {
         if (!cancelled) {
           isApplyingRef.current = false;
@@ -446,6 +452,12 @@ export function ViewerPage({
           .toPromise();
       } catch (err) {
         console.error('Error loading document:', err);
+        captureException(err, {
+          component: 'EmbedPdfViewer',
+          action: 'openDocumentBuffer',
+          pdfFileName,
+          selectedPdfId,
+        });
         // Reset the ref on error so we can retry
         previousSelectedPdfIdRef.current = previousPdfId;
       } finally {

--- a/packages/web/src/components/project/ProjectView.tsx
+++ b/packages/web/src/components/project/ProjectView.tsx
@@ -174,6 +174,7 @@ function ProjectViewInner({ projectId }: ProjectViewProps) {
             } catch (metaErr) {
               console.error('Failed to add PDF metadata:', metaErr);
               bestEffort(deletePdf(orgId, projectId, studyId, result.fileName), {
+                capture: true,
                 operation: 'deletePdf (pending upload rollback)',
                 projectId,
                 studyId,
@@ -234,6 +235,7 @@ function ProjectViewInner({ projectId }: ProjectViewProps) {
             } catch (metaErr) {
               console.error('Failed to add PDF metadata:', metaErr);
               bestEffort(deletePdf(orgId, projectId, studyId, result.file.fileName), {
+                capture: true,
                 operation: 'deletePdf (Google Drive rollback)',
                 projectId,
                 studyId,

--- a/packages/web/src/lib/errorLogger.ts
+++ b/packages/web/src/lib/errorLogger.ts
@@ -1,9 +1,12 @@
+import { captureException } from '@/config/sentry';
+
 export function bestEffort<T>(
   promise: Promise<T>,
   context: { operation?: string; [key: string]: unknown } = {},
 ): Promise<T | undefined> {
   return promise.catch(error => {
     console.warn(`Best-effort operation failed: ${context.operation || 'unknown'}`, error);
+    captureException(error, { action: context.operation ?? 'bestEffort', ...context });
     return undefined;
   });
 }

--- a/packages/web/src/lib/errorLogger.ts
+++ b/packages/web/src/lib/errorLogger.ts
@@ -2,11 +2,19 @@ import { captureException } from '@/config/sentry';
 
 export function bestEffort<T>(
   promise: Promise<T>,
-  context: { operation?: string; [key: string]: unknown } = {},
+  // `capture` opts a call site into Sentry. Off by default: most best-effort
+  // work is an IndexedDB cache write, which fails routinely under Safari
+  // private browsing and quota pressure, and reporting those would bury the
+  // real ones. Set it where the failure leaves state behind - a rollback that
+  // did not run orphans an R2 object. See guides/observability.md.
+  context: { operation?: string; capture?: boolean; [key: string]: unknown } = {},
 ): Promise<T | undefined> {
   return promise.catch(error => {
+    const { capture, ...details } = context;
     console.warn(`Best-effort operation failed: ${context.operation || 'unknown'}`, error);
-    captureException(error, { action: context.operation ?? 'bestEffort', ...context });
+    if (capture) {
+      captureException(error, { action: context.operation ?? 'bestEffort', ...details });
+    }
     return undefined;
   });
 }

--- a/packages/web/src/project/actions/pdfs.ts
+++ b/packages/web/src/project/actions/pdfs.ts
@@ -216,6 +216,7 @@ export const pdfActions = {
       });
       if (uploadResult?.fileName) {
         bestEffort(deletePdf(orgId, projectId, studyId, uploadResult.fileName), {
+          capture: true,
           operation: 'deletePdf (upload rollback)',
           projectId,
           studyId,
@@ -348,6 +349,7 @@ export const pdfActions = {
         fileName: file.fileName,
       });
       bestEffort(deletePdf(orgId, projectId, studyId, file.fileName), {
+        capture: true,
         operation: 'deletePdf (Google Drive rollback)',
         projectId,
         studyId,

--- a/packages/web/src/project/actions/pdfs.ts
+++ b/packages/web/src/project/actions/pdfs.ts
@@ -5,6 +5,7 @@
 import { uploadPdf, downloadPdf, deletePdf } from '@/api/pdf-api';
 import { cachePdf, removeCachedPdf, getCachedPdf } from '@/primitives/pdfCache.js';
 import { bestEffort } from '@/lib/errorLogger.js';
+import { captureException } from '@/config/sentry';
 import { extractPdfDoi, extractPdfTitle } from '@/lib/pdfUtils.js';
 import { fetchFromDOI } from '@/lib/referenceLookup.js';
 import type { PdfCitationMetadata, PdfRow, PdfTag } from '@corates/shared/sync';
@@ -100,6 +101,13 @@ export const pdfActions = {
       usePdfPreviewStore.getState().setData(data);
     } catch (err) {
       console.error('Error loading PDF:', err);
+      captureException(err, {
+        component: 'pdfActions',
+        action: 'view',
+        projectId,
+        studyId,
+        fileName: pdf.fileName,
+      });
       usePdfPreviewStore.getState().setError((err as Error).message || 'Failed to load PDF');
     }
   },
@@ -127,6 +135,13 @@ export const pdfActions = {
       URL.revokeObjectURL(url);
     } catch (err) {
       console.error('Error downloading PDF:', err);
+      captureException(err, {
+        component: 'pdfActions',
+        action: 'download',
+        projectId,
+        studyId,
+        fileName: pdf.fileName,
+      });
       throw err;
     }
   },
@@ -191,6 +206,14 @@ export const pdfActions = {
       return pdfId;
     } catch (err) {
       console.error('Error uploading PDF:', err);
+      captureException(err, {
+        component: 'pdfActions',
+        action: 'upload',
+        projectId,
+        studyId,
+        fileName: file.name,
+        size: file.size,
+      });
       if (uploadResult?.fileName) {
         bestEffort(deletePdf(orgId, projectId, studyId, uploadResult.fileName), {
           operation: 'deletePdf (upload rollback)',
@@ -219,6 +242,15 @@ export const pdfActions = {
         r2Deleted = true;
       } catch (r2Err) {
         console.error('Failed to delete PDF from R2:', r2Err);
+        // Captured here rather than in the outer catch: the rethrow below
+        // synthesizes a generic Error that would lose this cause.
+        captureException(r2Err, {
+          component: 'pdfActions',
+          action: 'delete.r2',
+          projectId,
+          studyId,
+          fileName: pdf.fileName,
+        });
       }
 
       try {
@@ -308,6 +340,13 @@ export const pdfActions = {
       });
     } catch (err) {
       console.error('Failed to add Google Drive PDF metadata:', err);
+      captureException(err, {
+        component: 'pdfActions',
+        action: 'handleGoogleDriveImport',
+        projectId,
+        studyId,
+        fileName: file.fileName,
+      });
       bestEffort(deletePdf(orgId, projectId, studyId, file.fileName), {
         operation: 'deletePdf (Google Drive rollback)',
         projectId,

--- a/packages/web/src/project/actions/project.ts
+++ b/packages/web/src/project/actions/project.ts
@@ -6,6 +6,7 @@
  */
 
 import { showToast } from '@/lib/toast';
+import { captureException } from '@/config/sentry';
 import { queryClient } from '@/lib/queryClient';
 import { queryKeys } from '@/lib/queryKeys';
 import { deleteProject, updateProject } from '@/server/functions/org-projects.functions';
@@ -25,6 +26,7 @@ export const projectActions = {
       queryClient.invalidateQueries({ queryKey: queryKeys.projects.all });
     } catch (err) {
       console.error('Error renaming project:', err);
+      captureException(err, { component: 'projectActions', action: 'rename' });
       showToast.error('Rename Failed', (err as Error).message || 'Failed to rename project');
     }
   },
@@ -44,6 +46,7 @@ export const projectActions = {
       queryClient.invalidateQueries({ queryKey: queryKeys.projects.all });
     } catch (err) {
       console.error('Error updating description:', err);
+      captureException(err, { component: 'projectActions', action: 'updateDescription' });
       showToast.error('Update Failed', (err as Error).message || 'Failed to update description');
     }
   },

--- a/packages/web/src/project/actions/studies.ts
+++ b/packages/web/src/project/actions/studies.ts
@@ -310,6 +310,7 @@ export const studyActions = {
       if (pdfFileNames.length > 0) {
         const deletePromises = pdfFileNames.map(fileName => {
           return bestEffort(deletePdf(orgId, projectId, studyId, fileName), {
+            capture: true,
             operation: 'deletePdf (study cleanup)',
             projectId,
             studyId,

--- a/packages/web/src/project/actions/studies.ts
+++ b/packages/web/src/project/actions/studies.ts
@@ -5,6 +5,7 @@
 import { uploadPdf, fetchPdfViaProxy, downloadPdf, deletePdf } from '@/api/pdf-api';
 import { cachePdf, clearStudyCache } from '@/primitives/pdfCache.js';
 import { bestEffort } from '@/lib/errorLogger.js';
+import { captureException } from '@/config/sentry';
 import { showToast } from '@/lib/toast';
 import { importFromGoogleDrive } from '@/api/google-drive';
 import { extractPdfDoi, extractPdfTitle } from '@/lib/pdfUtils.js';
@@ -176,6 +177,7 @@ async function handleGoogleDrivePdf(
     return true;
   } catch (err) {
     console.error('Error importing PDF from Google Drive:', err);
+    captureException(err, { component: 'studyActions', action: 'importPdfFromGoogleDrive' });
     return false;
   }
 }
@@ -244,6 +246,7 @@ async function uploadAndAttachPdf(
     return true;
   } catch (err) {
     console.error('Error uploading PDF:', err);
+    captureException(err, { component: 'studyActions', action: 'uploadAndAttachPdf' });
     return false;
   }
 }
@@ -326,6 +329,12 @@ export const studyActions = {
       void client.mutate.study.delete({ id: studyId });
     } catch (err) {
       console.error('Error deleting study:', err);
+      captureException(err, {
+        component: 'studyActions',
+        action: 'delete',
+        projectId,
+        studyId,
+      });
       showToast.error('Delete Failed', 'Failed to delete study');
     }
   },
@@ -417,6 +426,7 @@ export const studyActions = {
           successCount++;
         } catch (err) {
           console.error('Error adding study:', err);
+          captureException(err, { component: 'studyActions', action: 'addBatch.study' });
         }
       }
 
@@ -424,6 +434,7 @@ export const studyActions = {
       return { successCount, manualPdfCount };
     } catch (err) {
       console.error('Error adding studies:', err);
+      captureException(err, { component: 'studyActions', action: 'addBatch' });
       showToast.error('Addition Failed', 'Failed to add studies');
       throw err;
     }

--- a/packages/web/src/routes/api/auth/stripe/webhook.ts
+++ b/packages/web/src/routes/api/auth/stripe/webhook.ts
@@ -14,6 +14,7 @@ import { env } from 'cloudflare:workers';
 import { createAuth } from '@corates/workers/auth-config';
 import { sha256, truncateError } from '@corates/shared/crypto';
 import { createLogger } from '@corates/shared/logger';
+import { getRequestId } from '@corates/workers/logger';
 import type { Database } from '@corates/db/client';
 import {
   insertLedgerEntry,
@@ -51,7 +52,9 @@ const ROUTE = '/api/auth/stripe/webhook';
 
 export const handlePost = async ({ request, context }: HandlerArgs) => {
   const { db } = context;
-  const requestId = request.headers.get('x-request-id') ?? crypto.randomUUID();
+  // Reuse the id from the ambient request scope so these entries correlate
+  // with the rest of the request rather than opening a second trace.
+  const requestId = getRequestId() ?? request.headers.get('x-request-id') ?? crypto.randomUUID();
   const log = createLogger({
     service: 'corates-web',
     env: env.ENVIRONMENT,

--- a/packages/web/src/server.ts
+++ b/packages/web/src/server.ts
@@ -27,13 +27,24 @@ interface SentryEnv {
   CF_VERSION_METADATA?: { id?: string };
 }
 
+// This worker is public, so an inbound x-request-id is attacker-controlled: a
+// value reused across requests collapses correlation, and an oversized one is
+// copied into every log line of the request and shipped onward. Adopt one only
+// if it looks like an id we would have minted ourselves.
+const SAFE_REQUEST_ID = /^[A-Za-z0-9_-]{1,64}$/;
+
+function inboundRequestId(request: Request): string | null {
+  const id = request.headers.get('x-request-id');
+  return id && SAFE_REQUEST_ID.test(id) ? id : null;
+}
+
 const workerHandler = {
   async fetch(request: Request, env: unknown, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
     // Scope every log emitted while handling this request to one requestId.
-    // An inbound x-request-id wins so a caller's id survives across hops.
-    const requestId = request.headers.get('x-request-id') ?? crypto.randomUUID();
+    // A well-formed inbound x-request-id wins so a caller's id survives hops.
+    const requestId = inboundRequestId(request) ?? crypto.randomUUID();
 
     return runWithLogger(
       {

--- a/packages/web/src/server.ts
+++ b/packages/web/src/server.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/cloudflare';
 import { createStartHandler, defaultStreamHandler } from '@tanstack/react-start/server';
 import { handleEmailQueue } from '@corates/workers/queue';
+import { runWithLogger } from '@corates/workers/logger';
 import { handleSyncFetch } from '@corates/workers/sync';
 
 // Re-export DOs so wrangler DO bindings in wrangler.jsonc resolve against this
@@ -30,33 +31,59 @@ const workerHandler = {
   async fetch(request: Request, env: unknown, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
-    // DO routes must be handled before TanStack Start (which can't pass
-    // WebSocket upgrades through). Same Request is forwarded as-is so the
-    // upgrade handshake reaches the DO.
-    const sessionMatch = url.pathname.match(SESSION_PATH);
-    if (sessionMatch) {
-      const sessionId = sessionMatch[1];
-      const ns = (env as DOEnv).USER_SESSION;
-      const id = ns.idFromName(sessionId);
-      const stub = ns.get(id);
-      return stub.fetch(request);
-    }
+    // Scope every log emitted while handling this request to one requestId.
+    // An inbound x-request-id wins so a caller's id survives across hops.
+    const requestId = request.headers.get('x-request-id') ?? crypto.randomUUID();
 
-    // Sync-engine routes (`/api/sync/<projectId>` upgrades and
-    // `/api/sync-admin/...`): resolves null for anything else.
-    const syncResponse = await handleSyncFetch(request, env);
-    if (syncResponse) return syncResponse;
+    return runWithLogger(
+      {
+        requestId,
+        cfRay: request.headers.get('cf-ray'),
+        env: (env as SentryEnv).ENVIRONMENT,
+        context: { route: url.pathname, method: request.method },
+      },
+      async () => {
+        // DO routes must be handled before TanStack Start (which can't pass
+        // WebSocket upgrades through).
+        const sessionMatch = url.pathname.match(SESSION_PATH);
+        if (sessionMatch) {
+          const sessionId = sessionMatch[1];
+          const ns = (env as DOEnv).USER_SESSION;
+          const id = ns.idFromName(sessionId);
+          const stub = ns.get(id);
+          // AsyncLocalStorage does not cross the isolate boundary, so the id
+          // rides as a header instead and the DO reopens its own scope.
+          // Rebuilding the Request preserves the upgrade handshake (covered by
+          // durable-objects/__tests__/do-correlation).
+          const headers = new Headers(request.headers);
+          headers.set('x-request-id', requestId);
+          return stub.fetch(new Request(request, { headers }));
+        }
 
-    // Forward the Worker's ExecutionContext through TanStack Start so file
-    // routes can pass it into route handlers (waitUntil for fire-and-forget
-    // work like Stripe webhook ledger updates and notification fan-out).
-    // Cast: createStartHandler's RequestOptions.context defaults to a narrow
-    // BaseContext until we register a project-wide requestContext type.
-    return startFetch(request, { context: { cloudflareCtx: ctx } } as never);
+        // Sync-engine routes (`/api/sync/<projectId>` upgrades and
+        // `/api/sync-admin/...`): resolves null for anything else.
+        const syncResponse = await handleSyncFetch(request, env);
+        if (syncResponse) return syncResponse;
+
+        // Forward the Worker's ExecutionContext through TanStack Start so file
+        // routes can pass it into route handlers (waitUntil for fire-and-forget
+        // work like Stripe webhook ledger updates and notification fan-out).
+        // Cast: createStartHandler's RequestOptions.context defaults to a narrow
+        // BaseContext until we register a project-wide requestContext type.
+        return startFetch(request, { context: { cloudflareCtx: ctx } } as never);
+      },
+    );
   },
 
   async queue(batch: MessageBatch<unknown>, env: unknown): Promise<void> {
-    return handleEmailQueue(batch, env as never);
+    return runWithLogger(
+      {
+        requestId: crypto.randomUUID(),
+        env: (env as SentryEnv).ENVIRONMENT,
+        context: { queue: 'email', batchSize: batch.messages.length },
+      },
+      () => handleEmailQueue(batch, env as never),
+    );
   },
 };
 
@@ -73,6 +100,5 @@ export default Sentry.withSentry((env: SentryEnv) => {
     enabled: !!env.SENTRY_DSN,
     tracesSampleRate: env.ENVIRONMENT === 'production' ? 0.1 : 1.0,
     sendDefaultPii: true,
-    enableLogs: true,
   };
 }, workerHandler);

--- a/packages/web/src/server/middleware/auth.ts
+++ b/packages/web/src/server/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from '@tanstack/react-start';
 import { env } from 'cloudflare:workers';
 import { getSession } from '@corates/workers/auth';
+import { runWithContext } from '@corates/workers/logger';
 import { throwDomainError, AUTH_ERRORS } from '@corates/shared';
 import { dbMiddleware } from './db';
 
@@ -14,5 +15,9 @@ export const authMiddleware = createMiddleware()
     if (!session) {
       throwDomainError(AUTH_ERRORS.REQUIRED);
     }
-    return next({ context: { session, request } });
+    // Narrow the request scope opened in src/server.ts now that the caller is
+    // known, so downstream command logs carry userId alongside requestId.
+    return runWithContext({ userId: session.user.id }, () =>
+      next({ context: { session, request } }),
+    );
   });

--- a/packages/web/wrangler.jsonc
+++ b/packages/web/wrangler.jsonc
@@ -224,8 +224,7 @@
           "enabled": true,
           "head_sampling_rate": 1,
           "invocation_logs": true,
-          "persist": true,
-          "destinations": ["corates-loki"]
+          "persist": true
         }
       },
       "vars": {

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "@better-auth/stripe": "^1.6.26",
-    "@cf-sync/server": "^0.1.0",
-    "@cf-sync/yjs": "^0.1.0",
+    "@cf-sync/server": "^0.2.0",
+    "@cf-sync/yjs": "^0.2.0",
     "@corates/db": "workspace:*",
     "@corates/shared": "workspace:*",
     "@sentry/cloudflare": "^10.69.0",

--- a/packages/workers/src/durable-objects/UserSession.ts
+++ b/packages/workers/src/durable-objects/UserSession.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from 'cloudflare:workers';
-import { captureError } from '../lib/logger';
+import { captureError, info, runWithLogger } from '../lib/logger';
 import { instrumentDurableObjectWithSentry } from '@sentry/cloudflare';
 import { verifyAuth } from '../auth/config';
 import { getAccessControlOrigin } from '../config/origins';
@@ -16,7 +16,22 @@ interface WebSocketAttachment {
 }
 
 class UserSessionBase extends DurableObject<Env> {
+  // The calling worker's scope cannot follow the request across the isolate
+  // boundary, so it forwards its id as a header and we reopen a scope here.
+  // Requests that arrive without one still get a scope, just an unlinked one.
   async fetch(request: Request): Promise<Response> {
+    return runWithLogger(
+      {
+        requestId: request.headers.get('x-request-id') ?? crypto.randomUUID(),
+        cfRay: request.headers.get('cf-ray'),
+        env: this.env.ENVIRONMENT,
+        context: { durableObject: 'UserSession' },
+      },
+      () => this.handleFetch(request),
+    );
+  }
+
+  private async handleFetch(request: Request): Promise<Response> {
     const requestOrigin = request.headers.get('Origin');
     const corsHeaders: Record<string, string> = {
       'Access-Control-Allow-Origin': getAccessControlOrigin(requestOrigin),
@@ -80,6 +95,12 @@ class UserSessionBase extends DurableObject<Env> {
         }
         await this.ctx.storage.put('pendingNotifications', []);
       }
+
+      info('user-session websocket connected', {
+        action: 'websocket-upgrade',
+        userId: user.id,
+        pendingDelivered: pending.length,
+      });
 
       return new Response(null, { status: 101, webSocket: client });
     } catch (err) {

--- a/packages/workers/src/durable-objects/UserSession.ts
+++ b/packages/workers/src/durable-objects/UserSession.ts
@@ -20,12 +20,16 @@ class UserSessionBase extends DurableObject<Env> {
   // boundary, so it forwards its id as a header and we reopen a scope here.
   // Requests that arrive without one still get a scope, just an unlinked one.
   async fetch(request: Request): Promise<Response> {
+    const forwardedId = request.headers.get('x-request-id');
     return runWithLogger(
       {
-        requestId: request.headers.get('x-request-id') ?? crypto.randomUUID(),
+        requestId: forwardedId ?? crypto.randomUUID(),
         cfRay: request.headers.get('cf-ray'),
         env: this.env.ENVIRONMENT,
-        context: { durableObject: 'UserSession' },
+        // requestIdForwarded separates a log that joins back to a worker
+        // request from one carrying only a locally minted id, which are
+        // otherwise indistinguishable since both are UUIDs.
+        context: { durableObject: 'UserSession', requestIdForwarded: forwardedId !== null },
       },
       () => this.handleFetch(request),
     );

--- a/packages/workers/src/durable-objects/__tests__/do-correlation.test.ts
+++ b/packages/workers/src/durable-objects/__tests__/do-correlation.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Request correlation across the Durable Object boundary.
+ *
+ * AsyncLocalStorage does not survive `stub.fetch()`, so the calling worker
+ * forwards its requestId as a header and the DO reopens a scope from it. This
+ * pins both halves: that the header reaches the DO on a rebuilt WebSocket
+ * upgrade, and that the ALS scope genuinely does not cross (the reason the
+ * header exists at all).
+ *
+ * `verifyAuth` runs inside the DO with the Request the DO received, which
+ * makes it a probe for both without instrumenting production code.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { env } from 'cloudflare:workers';
+import { runWithLogger, getRequestId } from '../../lib/logger';
+
+const seen: Array<{ header: string | null; scopedRequestId: string | undefined }> = [];
+
+vi.mock('../../auth/config', () => ({
+  verifyAuth: vi.fn(async (request: Request) => {
+    seen.push({
+      header: request.headers.get('x-request-id'),
+      scopedRequestId: getRequestId(),
+    });
+    return { user: { id: 'user-do-1', email: 'do@example.com' }, session: null };
+  }),
+}));
+
+const USER = 'user-do-1';
+
+function upgradeRequest(headers: Record<string, string> = {}) {
+  return new Request(`https://internal/api/sessions/${USER}`, {
+    headers: {
+      Upgrade: 'websocket',
+      'Sec-WebSocket-Key': 'test-key',
+      'Sec-WebSocket-Version': '13',
+      ...headers,
+    },
+  });
+}
+
+function sessionStub() {
+  const ns = env.USER_SESSION;
+  return ns.get(ns.idFromName(USER));
+}
+
+function closeQuietly(response: Response) {
+  const socket = response.webSocket;
+  if (!socket) return;
+  socket.accept();
+  socket.close(1000, 'test-done');
+}
+
+describe('UserSession request correlation', () => {
+  beforeEach(() => {
+    seen.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('adopts a forwarded requestId, and the rebuilt upgrade still completes', async () => {
+    // Exactly what packages/web/src/server.ts does before stub.fetch().
+    const original = upgradeRequest();
+    const headers = new Headers(original.headers);
+    headers.set('x-request-id', 'req-abc-123');
+
+    const response = await sessionStub().fetch(new Request(original, { headers }));
+
+    expect(response.status).toBe(101);
+    expect(response.webSocket).toBeTruthy();
+    expect(seen).toHaveLength(1);
+    expect(seen[0].header).toBe('req-abc-123');
+    expect(seen[0].scopedRequestId).toBe('req-abc-123');
+    closeQuietly(response);
+  });
+
+  it('still opens a scope when no requestId is forwarded', async () => {
+    const response = await sessionStub().fetch(upgradeRequest());
+
+    expect(response.status).toBe(101);
+    expect(seen).toHaveLength(1);
+    expect(seen[0].header).toBeNull();
+    expect(seen[0].scopedRequestId).toEqual(expect.any(String));
+    closeQuietly(response);
+  });
+
+  it('does not inherit the caller scope implicitly - the header is what carries it', async () => {
+    const response = await runWithLogger({ requestId: 'req-als-999' }, async () => {
+      expect(getRequestId()).toBe('req-als-999');
+      // Deliberately forwarded without the header.
+      return sessionStub().fetch(upgradeRequest());
+    });
+
+    expect(response.status).toBe(101);
+    expect(seen).toHaveLength(1);
+    expect(seen[0].scopedRequestId).not.toBe('req-als-999');
+    closeQuietly(response);
+  });
+});

--- a/packages/workers/src/lib/logger.ts
+++ b/packages/workers/src/lib/logger.ts
@@ -51,7 +51,7 @@ export function runWithContext<T>(context: Record<string, unknown>, fn: () => T)
   return scopeStore.run(current().child(context), fn);
 }
 
-/** The active request's id, for echoing back as a response header. */
+/** The active request's id, for code that builds a logger of its own. */
 export function getRequestId(): string | undefined {
   return current().requestId;
 }
@@ -65,11 +65,6 @@ export function captureError(error: unknown, context?: ErrorContext): void {
     ...context?.extra,
   });
   Sentry.captureException(error, context);
-}
-
-export function debug(message: string, params?: LogParams): void {
-  const [msg, data] = normalize(message, params);
-  current().debug(msg, data);
 }
 
 export function info(message: string, params?: LogParams): void {

--- a/packages/workers/src/lib/logger.ts
+++ b/packages/workers/src/lib/logger.ts
@@ -1,5 +1,19 @@
+/**
+ * Server-side logging for the workers package.
+ *
+ * Logs are Loki-first: every entry is structured JSON on the console, which
+ * Cloudflare Workers Observability exports over OTLP (see infra/observability).
+ * Sentry is reserved for exceptions, where the stack trace and release mapping
+ * earn their keep — informational logs are not mirrored there.
+ *
+ * Request correlation rides on AsyncLocalStorage rather than a threaded
+ * parameter, so command signatures stay `(env, actor, params)` while their
+ * logs still carry requestId/cfRay. Entry points call `runWithLogger`.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
 import * as Sentry from '@sentry/cloudflare';
-import { createLogger } from '@corates/shared/logger';
+import { createLogger, type Logger } from '@corates/shared/logger';
 
 type LogParams = (string | number)[] | Record<string, unknown>;
 
@@ -8,11 +22,43 @@ interface ErrorContext {
   extra?: Record<string, unknown>;
 }
 
-const log = createLogger({ service: 'corates-workers' });
+export interface RequestScope {
+  requestId?: string;
+  cfRay?: string | null;
+  env?: string;
+  /** Static fields merged into every entry in this scope (e.g. route, method) */
+  context?: Record<string, unknown>;
+}
+
+const SERVICE = 'corates-workers';
+
+const scopeStore = new AsyncLocalStorage<Logger>();
+
+// Used by module-init code, tests, and anything running outside a request.
+const unscoped = createLogger({ service: SERVICE });
+
+function current(): Logger {
+  return scopeStore.getStore() ?? unscoped;
+}
+
+/** Establish a request-scoped logger. Entry points wrap their handler in this. */
+export function runWithLogger<T>({ requestId, cfRay, env, context }: RequestScope, fn: () => T): T {
+  return scopeStore.run(createLogger({ service: SERVICE, requestId, cfRay, env, context }), fn);
+}
+
+/** Merge fields into the ambient logger for the remainder of the current scope. */
+export function runWithContext<T>(context: Record<string, unknown>, fn: () => T): T {
+  return scopeStore.run(current().child(context), fn);
+}
+
+/** The active request's id, for echoing back as a response header. */
+export function getRequestId(): string | undefined {
+  return current().requestId;
+}
 
 export function captureError(error: unknown, context?: ErrorContext): void {
   const err = error instanceof Error ? error : undefined;
-  log.error(err?.message ?? String(error), {
+  current().error(err?.message ?? String(error), {
     ...(err?.name && err.name !== 'Error' && { errorName: err.name }),
     ...(err?.stack && { stack: err.stack }),
     ...context?.tags,
@@ -21,16 +67,19 @@ export function captureError(error: unknown, context?: ErrorContext): void {
   Sentry.captureException(error, context);
 }
 
-export function warn(message: string, params?: LogParams): void {
+export function debug(message: string, params?: LogParams): void {
   const [msg, data] = normalize(message, params);
-  log.warn(msg, data);
-  Sentry.logger.warn(message, toAttributes(params));
+  current().debug(msg, data);
 }
 
 export function info(message: string, params?: LogParams): void {
   const [msg, data] = normalize(message, params);
-  log.info(msg, data);
-  Sentry.logger.info(message, toAttributes(params));
+  current().info(msg, data);
+}
+
+export function warn(message: string, params?: LogParams): void {
+  const [msg, data] = normalize(message, params);
+  current().warn(msg, data);
 }
 
 // Array params come from printf-style call sites (`info('org %s', [orgId])`);
@@ -45,14 +94,4 @@ function normalize(
   const msg = message.replace(/%s/g, () => (i < params.length ? String(params[i++]) : '%s'));
   const rest = params.slice(i);
   return [msg, rest.length > 0 ? { params: rest } : undefined];
-}
-
-function toAttributes(params?: LogParams): Record<string, unknown> | undefined {
-  if (!params) return undefined;
-  if (!Array.isArray(params)) return params;
-  const attrs: Record<string, unknown> = {};
-  for (let i = 0; i < params.length; i++) {
-    attrs[`param.${i}`] = params[i];
-  }
-  return attrs;
 }

--- a/packages/workers/src/queue.ts
+++ b/packages/workers/src/queue.ts
@@ -3,7 +3,7 @@
  * worker (`packages/web/src/server.ts`) wires this into its Cloudflare
  * Workers `queue()` handler.
  */
-import { captureError, info } from './lib/logger';
+import { captureError, info, runWithContext } from './lib/logger';
 import { createEmailService } from './auth/email';
 import type { EmailPayload } from '@corates/shared/email';
 import type { Env } from './types';
@@ -33,39 +33,43 @@ export async function handleEmailQueue(batch: MessageBatch<unknown>, env: Env): 
   const emailService = createEmailService(env);
   const messages = batch.messages as Message<EmailPayload>[];
 
+  // The batch's scope is shared by every message in it, so without this a
+  // failed send cannot be told apart from its neighbours in the same batch.
   await Promise.allSettled(
-    messages.map(async msg => {
-      try {
-        if (await isAlreadyProcessed(env.DB, msg.id)) {
-          msg.ack();
-          return;
-        }
+    messages.map(msg =>
+      runWithContext({ messageId: msg.id }, async () => {
+        try {
+          if (await isAlreadyProcessed(env.DB, msg.id)) {
+            msg.ack();
+            return;
+          }
 
-        const result = await emailService.sendEmail(
-          msg.body as Parameters<typeof emailService.sendEmail>[0],
-        );
+          const result = await emailService.sendEmail(
+            msg.body as Parameters<typeof emailService.sendEmail>[0],
+          );
 
-        const masked = msg.body.to?.replace(/^(..).*@/, '$1***@');
-        if (result.success) {
-          await markProcessed(env.DB, msg.id);
-          info('email.sent', { to: masked, subject: msg.body.subject, attempt: msg.attempts });
-          msg.ack();
-        } else {
-          captureError(new Error(`Email send failed for ${masked}: ${result.error}`), {
+          const masked = msg.body.to?.replace(/^(..).*@/, '$1***@');
+          if (result.success) {
+            await markProcessed(env.DB, msg.id);
+            info('email.sent', { to: masked, subject: msg.body.subject, attempt: msg.attempts });
+            msg.ack();
+          } else {
+            captureError(new Error(`Email send failed for ${masked}: ${result.error}`), {
+              tags: { component: 'email-queue' },
+              extra: { attempt: msg.attempts },
+            });
+            const delay = Math.min(30 * 2 ** msg.attempts, 1800);
+            msg.retry({ delaySeconds: delay });
+          }
+        } catch (error) {
+          captureError(error, {
             tags: { component: 'email-queue' },
             extra: { attempt: msg.attempts },
           });
           const delay = Math.min(30 * 2 ** msg.attempts, 1800);
           msg.retry({ delaySeconds: delay });
         }
-      } catch (error) {
-        captureError(error, {
-          tags: { component: 'email-queue' },
-          extra: { attempt: msg.attempts },
-        });
-        const delay = Math.min(30 * 2 ** msg.attempts, 1800);
-        msg.retry({ delaySeconds: delay });
-      }
-    }),
+      }),
+    ),
   );
 }

--- a/packages/workers/src/sync/workspace.ts
+++ b/packages/workers/src/sync/workspace.ts
@@ -20,6 +20,7 @@ import { yjsFields } from '@cf-sync/yjs/server';
 import { syncApp } from '@corates/shared/sync';
 import { createDb } from '@corates/db/client';
 import { verifyAuth } from '../auth/config';
+import { captureError, warn } from '../lib/logger';
 import type { Env } from '../types';
 import { buildSyncVerdict } from './authorize';
 
@@ -32,6 +33,22 @@ export class WorkspaceDO extends createWorkspaceDO({
     app: syncApp,
     authorizeWrite: ({ auth }) => auth?.writeAllowed === true,
   }),
+  // Without this the engine's diagnostics go straight to console as plain
+  // interpolated strings, which reach Loki unparseable by field. These are
+  // the sync engine's init failures, schema-drift warnings and internal
+  // errors, so they are the ones worth querying.
+  logger: (level, message, ...detail) => {
+    const error = detail.find((d): d is Error => d instanceof Error);
+    const extra = detail.filter(d => !(d instanceof Error));
+    if (level === 'error') {
+      captureError(error ?? new Error(message), {
+        tags: { component: 'cf-sync' },
+        extra: { engineMessage: message, ...(extra.length > 0 && { detail: extra }) },
+      });
+      return;
+    }
+    warn(message, { component: 'cf-sync', ...(detail.length > 0 && { detail }) });
+  },
 }) {}
 
 export const SYNC_PATH_PREFIX = '/api/sync';

--- a/packages/workers/src/sync/workspace.ts
+++ b/packages/workers/src/sync/workspace.ts
@@ -36,18 +36,25 @@ export class WorkspaceDO extends createWorkspaceDO({
   // Without this the engine's diagnostics go straight to console as plain
   // interpolated strings, which reach Loki unparseable by field. These are
   // the sync engine's init failures, schema-drift warnings and internal
-  // errors, so they are the ones worth querying.
-  logger: (level, message, ...detail) => {
+  // errors, so they are the ones worth querying. The workspace id IS the
+  // projectId, so logging it under that name joins these against the rest of
+  // the project's logs — the engine's own logs carry no requestId, because
+  // they fire at DO construction and on live sockets, never inside a request.
+  logger: (level, message, { workspaceId }, ...detail) => {
     const error = detail.find((d): d is Error => d instanceof Error);
     const extra = detail.filter(d => !(d instanceof Error));
     if (level === 'error') {
       captureError(error ?? new Error(message), {
-        tags: { component: 'cf-sync' },
+        tags: { component: 'cf-sync', projectId: workspaceId },
         extra: { engineMessage: message, ...(extra.length > 0 && { detail: extra }) },
       });
       return;
     }
-    warn(message, { component: 'cf-sync', ...(detail.length > 0 && { detail }) });
+    warn(message, {
+      component: 'cf-sync',
+      projectId: workspaceId,
+      ...(detail.length > 0 && { detail }),
+    });
   },
 }) {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@cf-sync/server':
-        specifier: ^0.1.0
-        version: 0.1.0(zod@4.4.3)
+        specifier: ^0.2.0
+        version: 0.2.0(zod@4.4.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -141,8 +141,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@tanstack/db@0.6.17(typescript@5.9.3))(@tanstack/react-db@0.1.95(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(zod@4.4.3)
       '@cf-sync/yjs':
-        specifier: ^0.1.0
-        version: 0.1.0(@cf-sync/server@0.1.0(zod@4.4.3))(react@19.2.8)(yjs@13.6.32)(zod@4.4.3)
+        specifier: ^0.2.0
+        version: 0.2.0(@cf-sync/server@0.2.0(zod@4.4.3))(react@19.2.8)(yjs@13.6.32)(zod@4.4.3)
       '@corates/db':
         specifier: workspace:*
         version: link:../db
@@ -337,8 +337,8 @@ importers:
         version: 5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     devDependencies:
       '@cf-sync/server':
-        specifier: ^0.1.0
-        version: 0.1.0(zod@4.4.3)
+        specifier: ^0.2.0
+        version: 0.2.0(zod@4.4.3)
       '@cloudflare/vite-plugin':
         specifier: ^1.51.1
         version: 1.51.1(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.23.11)(yaml@2.8.2))(wrangler@4.120.0(@cloudflare/workers-types@5.20260808.1))
@@ -412,11 +412,11 @@ importers:
         specifier: ^1.6.26
         version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260808.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.4)(nanostores@1.4.2))(better-auth@1.6.26(67e86c569e0676fbf2061b5ae6ecd26f))(better-call@1.3.7(zod@4.4.3))(stripe@22.4.0(@types/node@26.2.0))
       '@cf-sync/server':
-        specifier: ^0.1.0
-        version: 0.1.0(zod@4.4.3)
+        specifier: ^0.2.0
+        version: 0.2.0(zod@4.4.3)
       '@cf-sync/yjs':
-        specifier: ^0.1.0
-        version: 0.1.0(@cf-sync/server@0.1.0(zod@4.4.3))(react@19.2.8)(yjs@13.6.32)(zod@4.4.3)
+        specifier: ^0.2.0
+        version: 0.2.0(@cf-sync/server@0.2.0(zod@4.4.3))(react@19.2.8)(yjs@13.6.32)(zod@4.4.3)
       '@corates/db':
         specifier: workspace:*
         version: link:../db
@@ -850,15 +850,15 @@ packages:
     peerDependencies:
       zod: ^4.0.0
 
-  '@cf-sync/server@0.1.0':
-    resolution: {integrity: sha512-3lPlK8X1dUxwqVP4mUi27bS9zewNppDupmUF3eUENCl6HIk3yZ08EmeCVtzBDO6JQbTzkGYwicYu9F8s1yG2GQ==}
+  '@cf-sync/server@0.2.0':
+    resolution: {integrity: sha512-R1iOaAKke5ik4bwAZCaH7BdOJJaa2F0IfONroNkGGJy/k8pjLrWESO947Pm8DSSjhFe3tgjxZcFDihjZF+KvGw==}
     peerDependencies:
       zod: ^4.0.0
 
-  '@cf-sync/yjs@0.1.0':
-    resolution: {integrity: sha512-1sU+UBB2EKfHf8zlWdalWJzwnePbskgO1TYVOG1gk3TiaRVdQfH8ySlXsPc6Rq86Lwi04T2H0oymdIT4UILoyg==}
+  '@cf-sync/yjs@0.2.0':
+    resolution: {integrity: sha512-iRofMCo8OWuyDcMWM9TSJpo27uJouf67/60esW6YDwLPpV0KO7uLkmvMqCZFP3Y+22pQDP/MJBwWTqdsX/MENQ==}
     peerDependencies:
-      '@cf-sync/server': ^0.1.0
+      '@cf-sync/server': ^0.2.0
       react: '>=18'
       yjs: ^13.6.0
     peerDependenciesMeta:
@@ -9197,17 +9197,17 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@cf-sync/server@0.1.0(zod@4.4.3)':
+  '@cf-sync/server@0.2.0(zod@4.4.3)':
     dependencies:
       '@cf-sync/protocol': 0.1.1(zod@4.4.3)
       zod: 4.4.3
 
-  '@cf-sync/yjs@0.1.0(@cf-sync/server@0.1.0(zod@4.4.3))(react@19.2.8)(yjs@13.6.32)(zod@4.4.3)':
+  '@cf-sync/yjs@0.2.0(@cf-sync/server@0.2.0(zod@4.4.3))(react@19.2.8)(yjs@13.6.32)(zod@4.4.3)':
     dependencies:
       '@cf-sync/protocol': 0.1.1(zod@4.4.3)
       yjs: 13.6.32
     optionalDependencies:
-      '@cf-sync/server': 0.1.0(zod@4.4.3)
+      '@cf-sync/server': 0.2.0(zod@4.4.3)
       react: 19.2.8
     transitivePeerDependencies:
       - zod


### PR DESCRIPTION
## Summary

Server logging becomes Loki-first with real request correlation, and Sentry narrows to exceptions only.

- **Request correlation.** The workers logger bound one module-level instance with no `requestId`, so commands, auth, queue and sync logs could not be tied to the request that caused them. Scope now rides on `AsyncLocalStorage`, keeping command signatures at `(env, actor, params)` while their logs carry `requestId`, `cfRay` and `env`. `server.ts` opens the scope for `fetch` and `queue`; `authMiddleware` narrows it with `userId`, and the email queue narrows per message with `messageId` so one failed send is separable from its batch.
- **Inbound ids are validated.** An inbound `x-request-id` still wins so a caller's id survives across hops, but only if it matches `^[A-Za-z0-9_-]{1,64}$`. The header is attacker-controlled on a public worker: one fixed value collapses correlation for everything that client touches, and an oversized one would be copied into every log line of the request and shipped onward.
- **Across the DO boundary.** ALS does not cross into a Durable Object, so the id is forwarded to `UserSession` as an `x-request-id` header and the DO reopens its own scope.
- **Loki-first.** `info`/`warn` no longer mirror into `Sentry.logger.*` (Loki already keeps 100% of them at `head_sampling_rate: 1`), and the now-dead `enableLogs` is dropped from both worker entries. `captureError` still reports exceptions.
- **Production-only export.** Staging kept the same `corates-loki` destination as production, which mixed both environments into the Grafana views. Staging drops the destination and keeps `persist: true`, so its logs stay in Cloudflare Workers Logs where the e2e magic-link flow already reads them.
- **Browser.** Catch sites that silently swallowed user-visible failures now `captureException`. No browser-to-Loki path exists, so these stay on Sentry. `bestEffort` is the exception: it warns by default and reports only where a call site passes `capture: true`, since most of its uses are IndexedDB cache writes that fail routinely under Safari private browsing and quota pressure. The rollback deletes do pass it - a rollback that did not run orphans an object in R2.
- **Docs.** New `guides/observability.md` covering the entry shape, which logger to use where, correlation, levels, and LogQL.
- Removed the unused `onEntry` hook from the shared logger, and the unused `debug` export from the workers logger.
- Added `.claude/worktrees/**` to the eslint ignore list. Agent worktrees are full checkouts of other branches, so `pnpm lint` was reporting another branch's problems against this one.

## Correcting a stale comment

`server.ts` previously claimed the upgrade Request had to be forwarded untouched or the WebSocket handshake would break. That turns out not to hold: rebuilding it with `new Request(request, { headers })` completes a 101 with a live socket. `durable-objects/__tests__/do-correlation.test.ts` pins both that and the fact that the ALS scope genuinely does not cross (which is why the header is needed).

If that comment came from a real incident, the context is worth knowing before this merges.

## Still unscoped

- **`WorkspaceDO`.** Its diagnostics now route through the shared logger and join on `projectId` rather than `requestId` - no engine diagnostic fires inside a request, since init runs at DO construction and internal errors on a live socket. They also do not reach Sentry: the class is not wrapped in `instrumentDurableObjectWithSentry`, so `captureError`'s Sentry half is a no-op inside that isolate. Loki is the intended destination for them and that half works.
- **Hibernated WebSocket callbacks,** which fire long after the originating request.

Note on transport for the sync path: `handleSyncFetch` is called with the original Request, so `x-request-id` only reaches `WorkspaceDO` when a client sent one. `createSyncRoute` does forward headers to the stub, so wiring it up later is a one-line change - there is just nothing in the DO today that would read it.

## Testing

`pnpm lint`, `pnpm typecheck`, workers (84) and web (328) suites, and `pnpm --filter web build` all pass.

Staging verification of the `requestId` match across the DO boundary is still outstanding - it needs this branch's CI-built staging environment. Since staging no longer exports to Loki, that check reads Cloudflare Workers Logs (`wrangler tail` or the dashboard) rather than Grafana.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an Observability guide covering structured logging, request correlation, error monitoring, and Loki/Grafana troubleshooting.
  - Added the guide to the documentation navigation.

- **Improvements**
  - Improved request and background-task correlation across application services.
  - Added richer error reporting for PDF actions, project updates, imports, printing, and document handling.
  - Reduced routine informational and warning logs sent to error monitoring while preserving exception reporting.
  - Improved logging context for authenticated requests and real-time connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
