### PR TITLE
test: fix e2e study assertions broken by the removed study-count line

### DIFF
--- a/packages/web/e2e/persistence-recovery.spec.ts
+++ b/packages/web/e2e/persistence-recovery.spec.ts
@@ -21,7 +21,7 @@ import {
   updateSubscription,
   type DualReviewerScenario,
 } from './helpers';
-import { setupProjectWithStudy } from './shared-steps';
+import { setupProjectWithStudy, studyCardTitle } from './shared-steps';
 
 let scenario: DualReviewerScenario;
 
@@ -67,7 +67,7 @@ test('Project state survives page refresh', async ({ context, page }) => {
   // Step 1: After project setup, verify the study is visible
   // ================================================================
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({
+  await expect(studyCardTitle(page)).toBeVisible({
     timeout: 10_000,
   });
 
@@ -127,7 +127,7 @@ test('Project state survives page refresh', async ({ context, page }) => {
   await page.goto(`/projects/${projectId}`);
 
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({
+  await expect(studyCardTitle(page)).toBeVisible({
     timeout: 15_000,
   });
 
@@ -173,7 +173,7 @@ test('Project state survives page refresh', async ({ context, page }) => {
   // And the study should still be in the project list
   await page.goto(`/projects/${projectId}`);
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({
+  await expect(studyCardTitle(page)).toBeVisible({
     timeout: 10_000,
   });
 });
@@ -259,7 +259,7 @@ test('Project data survives navigate-away and navigate-back (cached phase)', asy
 
   // Verify study is present after initial setup
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({ timeout: 10_000 });
+  await expect(studyCardTitle(page)).toBeVisible({ timeout: 10_000 });
 
   // Navigate away to dashboard (releases the connection, destroys Y.Doc in memory)
   await page.goto('/dashboard');
@@ -269,7 +269,7 @@ test('Project data survives navigate-away and navigate-back (cached phase)', asy
   // before the WebSocket finishes syncing
   await page.goto(`/projects/${projectId}`);
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({ timeout: 15_000 });
+  await expect(studyCardTitle(page)).toBeVisible({ timeout: 15_000 });
 
   // Navigate away and back a second time to confirm the cache + sync pipeline
   // leaves Dexie in a consistent state across multiple visits
@@ -278,7 +278,7 @@ test('Project data survives navigate-away and navigate-back (cached phase)', asy
 
   await page.goto(`/projects/${projectId}`);
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({ timeout: 15_000 });
+  await expect(studyCardTitle(page)).toBeVisible({ timeout: 15_000 });
 });
 
 test('Concurrent server-side change merges correctly on revisit', async ({ context, page }) => {
@@ -290,7 +290,7 @@ test('Concurrent server-side change merges correctly on revisit', async ({ conte
   );
 
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({ timeout: 10_000 });
+  await expect(studyCardTitle(page)).toBeVisible({ timeout: 10_000 });
 
   // Navigate away so the connection is released
   await page.goto('/dashboard');
@@ -304,18 +304,20 @@ test('Concurrent server-side change merges correctly on revisit', async ({ conte
     fillMode: 'random',
   });
 
-  // Navigate back -- Dexie cache may briefly show 1 study,
-  // but after WebSocket sync, both studies should appear
+  // Navigate back -- Dexie cache may briefly show only the PDF-added study,
+  // but after WebSocket sync, both studies should appear. seedStudies names
+  // its studies "Generated Study <n>", numbered from 1.
   await page.goto(`/projects/${projectId}`);
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/2 studies in this project/i)).toBeVisible({ timeout: 30_000 });
+  await expect(studyCardTitle(page)).toBeVisible({ timeout: 30_000 });
+  await expect(studyCardTitle(page, 'Generated Study 1')).toBeVisible({ timeout: 30_000 });
 });
 
 test('Project actions work after cold reload (no warm query cache)', async ({ context, page }) => {
   await setupProjectWithStudy(context, page, scenario, 'Cold Reload Actions E2E');
 
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({ timeout: 10_000 });
+  await expect(studyCardTitle(page)).toBeVisible({ timeout: 10_000 });
 
   const pageErrors: Error[] = [];
   page.on('pageerror', err => pageErrors.push(err));
@@ -327,7 +329,7 @@ test('Project actions work after cold reload (no warm query cache)', async ({ co
   await page.reload();
 
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({ timeout: 15_000 });
+  await expect(studyCardTitle(page)).toBeVisible({ timeout: 15_000 });
 
   // Wait well past any sync window to prove this is not a race condition.
   await page.waitForTimeout(5_000);
@@ -348,7 +350,7 @@ test('Rapid navigation does not corrupt state or crash', async ({ context, page 
   const projectId = await setupProjectWithStudy(context, page, scenario, 'Rapid Nav E2E');
 
   await page.getByRole('tab', { name: /All Studies/i }).click();
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({ timeout: 10_000 });
+  await expect(studyCardTitle(page)).toBeVisible({ timeout: 10_000 });
 
   // Rapid-fire navigate: project -> dashboard -> project -> dashboard -> project
   // Each transition acquires/releases the connection. Tests ref-counting cleanup
@@ -359,6 +361,6 @@ test('Rapid navigation does not corrupt state or crash', async ({ context, page 
 
     await page.goto(`/projects/${projectId}`);
     await page.getByRole('tab', { name: /All Studies/i }).click();
-    await expect(page.getByText(/1 study in this project/i)).toBeVisible({ timeout: 15_000 });
+    await expect(studyCardTitle(page)).toBeVisible({ timeout: 15_000 });
   }
 });

--- a/packages/web/e2e/shared-steps.ts
+++ b/packages/web/e2e/shared-steps.ts
@@ -236,6 +236,17 @@ export async function createProject(page: Page, name: string, description = ''):
 }
 
 /**
+ * Locates a study card by its title in the All Studies list.
+ *
+ * The card titles a PDF-added study with the filename stem, and renders it as
+ * the inline-edit button. Matching on the button role keeps this off the same
+ * title text in the staged-import preview, which is plain text.
+ */
+export function studyCardTitle(page: Page, studyName = 'Petrie2019') {
+  return page.getByRole('button', { name: studyName, exact: true });
+}
+
+/**
  * Adds a study to the current project by uploading a PDF fixture.
  * No external API calls -- metadata is extracted locally from the PDF.
  */
@@ -249,7 +260,9 @@ export async function addStudyViaPdf(page: Page, fixture = 'Petrie2019.pdf') {
   await expect(page.getByRole('button', { name: /Add 1 Stud/i })).toBeVisible({ timeout: 30_000 });
   await page.getByRole('button', { name: /Add 1 Stud/i }).click();
 
-  await expect(page.getByText(/1 study in this project/i)).toBeVisible({ timeout: 15_000 });
+  await expect(studyCardTitle(page, fixture.replace(/\.pdf$/i, ''))).toBeVisible({
+    timeout: 15_000,
+  });
 }
 
 /**


### PR DESCRIPTION
## What broke

The first `main` run after PR #540 merged failed in `e2e`: [run 31293220013](https://github.com/InfinityBowman/corates/actions/runs/31293220013). 14 tests failed with the same error and `deploy-production` was skipped, so production never shipped that merge.

```
Error: expect(locator).toBeVisible() failed
Locator: getByText(/1 study in this project/i)
Error: element(s) not found
   at addStudyViaPdf (packages/web/e2e/shared-steps.ts:252)
```

Commit `badec191` removed the study-count line from `AllStudiesTab.tsx`:

```jsx
-  <p className='text-muted-foreground text-sm'>
-    {studyIds.length} {studyIds.length === 1 ? 'study' : 'studies'} in this project
-  </p>
```

`addStudyViaPdf` used that text as its "study was added" signal, so every test that seeds a study hung at the shared setup gate. Product code is fine; the assertion was stale.

## Why the PR that caused it went green

`ci.yml` gates `deploy-staging` on `if: github.event_name == 'push'`, and `e2e` -> `deploy-production` inherit that skip through `needs`. On PRs only `checks` runs. E2E first executes after merge, against the freshly deployed staging.

## The fix

Assert on the study card's own title. `getStudyNameFromFilename` (`packages/web/src/project/actions/studies.ts:36`) names a PDF-added study after the filename stem, and `StudyCardHeader` renders it through `InlineEdit` as a `<button>`. Matching the button role keeps the locator off the identical title text in the staged-import preview, which is plain text.

Extracted as a `studyCardTitle(page, studyName)` helper and applied to all 13 call sites. The two-study assertion now checks both cards by name (`Petrie2019` plus the seeded `Generated Study 1`) rather than a count string, which is a stronger check than what it replaced.

## Verification

`pnpm typecheck` and `pnpm lint` pass. E2E was run against staging (see PR comments) since the `e2e` job does not run on pull requests.