### PR TITLE
web: report the real member count on dashboard project cards

### DIFF
--- a/packages/web/src/components/dashboard/ProjectCard.tsx
+++ b/packages/web/src/components/dashboard/ProjectCard.tsx
@@ -21,7 +21,6 @@ export function ProjectCard({ project, onOpen, onDelete, style }: ProjectCardPro
   const colors = useMemo(() => getAccentColors(project.id), [project.id]);
 
   const relativeTime = formatRelativeTime(project.updatedAt || project.createdAt);
-  const memberCount = project.memberCount || project.members?.length || 1;
   const isOwner = project.role === 'owner';
 
   return (
@@ -74,7 +73,7 @@ export function ProjectCard({ project, onOpen, onDelete, style }: ProjectCardPro
           <div className='text-muted-foreground flex items-center gap-1.5 text-xs'>
             <UsersIcon className='size-3.5' />
             <span>
-              {memberCount} member{memberCount !== 1 ? 's' : ''}
+              {project.memberCount} member{project.memberCount !== 1 ? 's' : ''}
             </span>
           </div>
           <Button

--- a/packages/web/src/hooks/useMyProjectsList.ts
+++ b/packages/web/src/hooks/useMyProjectsList.ts
@@ -7,13 +7,11 @@ import { queryKeys } from '@/lib/queryKeys';
 import { QUERY_STABLE } from '@/lib/queryPresets';
 import { useAuthStore, selectIsLoggedIn, selectIsAuthLoading } from '@/stores/authStore';
 import { getMyProjects } from '@/server/functions/users.functions';
-import type { UserProject } from '@/server/functions/users.server';
+import type { UserProjectWithMemberCount } from '@/server/functions/users.server';
 
-export type Project = UserProject & {
+export type Project = UserProjectWithMemberCount & {
   studyCount?: number;
   completedCount?: number;
-  memberCount?: number;
-  members?: unknown[];
 };
 
 export function useMyProjectsList(options: { enabled?: boolean } = {}) {

--- a/packages/web/src/server/functions/__tests__/users-projects.server.test.ts
+++ b/packages/web/src/server/functions/__tests__/users-projects.server.test.ts
@@ -3,8 +3,13 @@ import { env } from 'cloudflare:workers';
 import { DomainErrorException } from '@corates/shared';
 import { createDb } from '@corates/db/client';
 import { resetTestDatabase } from '@/__tests__/server/helpers';
-import { buildUser, buildProject, resetCounter } from '@/__tests__/server/factories';
-import { fetchUserProjects } from '@/server/functions/users.server';
+import {
+  buildUser,
+  buildProject,
+  buildProjectWithMembers,
+  resetCounter,
+} from '@/__tests__/server/factories';
+import { fetchMyProjects, fetchUserProjects } from '@/server/functions/users.server';
 
 let currentUser = { id: 'user-1', email: 'user1@example.com' };
 
@@ -32,6 +37,29 @@ describe('GET /api/users/:userId/projects', () => {
     expect(result[0].id).toBeDefined();
     expect(result[0].name).toBeDefined();
     expect(result[0].role).toBeDefined();
+  });
+
+  it('reports the full member count per project', async () => {
+    const { project, owner, org } = await buildProjectWithMembers({ memberCount: 2 });
+    const { project: solo } = await buildProject({ org, owner });
+    currentUser = { id: owner.id, email: owner.email };
+
+    const result = await fetchMyProjects(createDb(env.DB), mockSession());
+
+    expect(result.find(p => p.id === project.id)?.memberCount).toBe(3);
+    expect(result.find(p => p.id === solo.id)?.memberCount).toBe(1);
+  });
+
+  it('does not count members of projects the user is not in', async () => {
+    const { project, owner } = await buildProject();
+    await buildProjectWithMembers({ memberCount: 2 });
+    currentUser = { id: owner.id, email: owner.email };
+
+    const result = await fetchMyProjects(createDb(env.DB), mockSession());
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(project.id);
+    expect(result[0].memberCount).toBe(1);
   });
 
   it('denies access to another user projects', async () => {

--- a/packages/web/src/server/functions/users.server.ts
+++ b/packages/web/src/server/functions/users.server.ts
@@ -11,7 +11,8 @@ import {
   twoFactor,
   mediaFiles,
 } from '@corates/db/schema';
-import { eq, or, desc } from 'drizzle-orm';
+import { eq, or, desc, count } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/sqlite-core';
 import { containsInsensitive } from '@/server/lib/sqlSearch';
 import { kickWorkspaceUser } from '@corates/workers/sync';
 import {
@@ -32,6 +33,10 @@ export interface UserProject {
   role: string;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface UserProjectWithMemberCount extends UserProject {
+  memberCount: number;
 }
 
 export interface UserSearchResult {
@@ -82,6 +87,11 @@ export async function deleteAccount(db: Database, session: Session) {
 }
 
 export async function fetchMyProjects(db: Database, session: Session) {
+  // Second join over the same table: the first is filtered to the caller's own
+  // membership (for `role`), this one stays unfiltered so the count covers every
+  // member. The (projectId, userId) unique index keeps the count exact.
+  const allMembers = alias(projectMembers, 'all_members');
+
   const results = await db
     .select({
       id: projects.id,
@@ -91,13 +101,16 @@ export async function fetchMyProjects(db: Database, session: Session) {
       role: projectMembers.role,
       createdAt: projects.createdAt,
       updatedAt: projects.updatedAt,
+      memberCount: count(allMembers.id),
     })
     .from(projects)
     .innerJoin(projectMembers, eq(projects.id, projectMembers.projectId))
+    .innerJoin(allMembers, eq(projects.id, allMembers.projectId))
     .where(eq(projectMembers.userId, session.user.id))
+    .groupBy(projects.id, projectMembers.role)
     .orderBy(desc(projects.updatedAt));
 
-  return results as unknown as UserProject[];
+  return results as unknown as UserProjectWithMemberCount[];
 }
 
 export async function fetchUserProjects(db: Database, session: Session, userId: string) {


### PR DESCRIPTION
Every project card on the dashboard reported "1 member" no matter how many people were on the project.

## Cause

`fetchMyProjects` selects id, name, description, orgId, role, createdAt and updatedAt, and nothing else. `ProjectCard` computed its count as:

```ts
const memberCount = project.memberCount || project.members?.length || 1;
```

Both of those fields were declared optional on the `Project` type but never populated by the server, so the expression always fell through to the literal `1`.

## Fix

Join `project_members` a second time under an alias and count it. The first join stays filtered to the caller's own membership because it supplies `role`; the aliased join is unfiltered so the count covers every member. The `(projectId, userId)` unique index makes the count exact, so this remains one query with no extra round trip.

`memberCount` is now required on the type the hook exposes, and the `|| 1` fallback is gone, so a missing count can no longer render as a plausible-looking one. The `members` field was removed with it: nothing ever populated it, and the fallback was its only reader.

## Testing

Two new cases in `users-projects.server.test.ts`:

- a project with an owner plus two members reports 3, while a solo project in the same org reports 1
- members of a project the user does not belong to do not leak into their counts

`pnpm --filter web test:server` (42 files, 330 tests), `test:unit` (583 tests), `pnpm typecheck` and `pnpm lint` all pass.

## Notes

No overlap with #541 — disjoint file sets, and that PR's `middleware/auth.ts` change only wraps `next()` in `runWithContext` without altering the `session` shape this query reads. Either merge order works.

`studyCount` and `completedCount` on the same type are also never populated by the server, but nothing renders them, so they are left alone.
