### PR TITLE
test: unstick the Outcomes sheet and the concurrent-CRDT setup context

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -96,7 +96,11 @@ jobs:
           path: packages/web/test-results/
           retention-days: 7
 
+      # Explicit bash: this job runs in the Playwright container, where the
+      # default shell is dash and the ${GITHUB_SHA:0:8} substring expansion
+      # fails, turning a green suite into a red job.
       - name: Summary
         if: always()
+        shell: bash
         run: |
           echo "E2E on staging for \`${{ github.ref_name }}\` (${GITHUB_SHA:0:8}): ${{ job.status }}." >> "$GITHUB_STEP_SUMMARY"

--- a/packages/web/e2e/concurrent-crdt.spec.ts
+++ b/packages/web/e2e/concurrent-crdt.spec.ts
@@ -290,24 +290,28 @@ test.describe('Concurrent CRDT: AMSTAR2', () => {
 
     const checklistUrlB = await openEditableChecklist(setupPage);
 
-    // Wait for the checklist to fully load before closing the setup context.
-    // Without this, setupCtx.close() can kill the WebSocket before the Y.Doc
-    // update (Bob's checklist creation) reaches the Durable Object.
     await expect(setupPage.getByText('AMSTAR2 Checklist').first()).toBeVisible({ timeout: 15_000 });
     await setupPage.goto(`${BASE_URL}/projects/${projectId}`);
     await expect(setupPage.getByRole('tab', { name: /To Do/i })).toBeVisible({ timeout: 15_000 });
 
-    await setupCtx.close();
-
-    await runConcurrentEditCycle(browser, scenario, projectId, checklistUrlA, checklistUrlB, {
-      loadedSelector: 'AMSTAR2 Checklist',
-      clickA: (page, count) => clickUncheckedCheckboxes(page, count),
-      clickB: (page, count) => clickUncheckedCheckboxes(page, count),
-      countA: page => countCheckedCheckboxes(page),
-      countB: page => countCheckedCheckboxes(page),
-      round1Count: 5,
-      round2Count: 3,
-    });
+    // Hold the setup context open through the cycle. Checklist creation is a
+    // fire-and-forget mutation, so a rendered checklist only proves the local
+    // optimistic apply happened -- the outbox entry may still be unsent, and
+    // closing the context destroys the only copy of it. Keeping the client
+    // connected lets the outbox drain while the cycle's own contexts start up.
+    try {
+      await runConcurrentEditCycle(browser, scenario, projectId, checklistUrlA, checklistUrlB, {
+        loadedSelector: 'AMSTAR2 Checklist',
+        clickA: (page, count) => clickUncheckedCheckboxes(page, count),
+        clickB: (page, count) => clickUncheckedCheckboxes(page, count),
+        countA: page => countCheckedCheckboxes(page),
+        countB: page => countCheckedCheckboxes(page),
+        round1Count: 5,
+        round2Count: 3,
+      });
+    } finally {
+      await setupCtx.close();
+    }
   });
 });
 
@@ -401,32 +405,38 @@ test.describe('Concurrent CRDT: ROB2', () => {
     });
     await fillROB2Preliminary(setupPage, 'Drug B', 'Standard care');
 
-    await setupCtx.close();
-
     // ROB2 uses toggle buttons (Y/PY/PN/N/NI) instead of radios.
     // Expand D1 on both pages before clicking, since domain sections
     // are collapsible. The concurrent cycle will click within D1's
     // visible signalling questions.
-    await runConcurrentEditCycle(browser, scenario, projectId, checklistUrlA, checklistUrlB, {
-      loadedSelector: 'D1',
-      clickA: async (page, count) => {
-        await page.getByRole('button', { name: 'D1', exact: true }).click();
-        await expect(page.getByRole('button', { name: 'Y', exact: true }).first()).toBeVisible({
-          timeout: 5_000,
-        });
-        return clickROB2Buttons(page, 'Y', count);
-      },
-      clickB: async (page, count) => {
-        await page.getByRole('button', { name: 'D1', exact: true }).click();
-        await expect(page.getByRole('button', { name: 'N', exact: true }).first()).toBeVisible({
-          timeout: 5_000,
-        });
-        return clickROB2Buttons(page, 'N', count);
-      },
-      countA: page => countSelectedROB2Buttons(page, 'Y'),
-      countB: page => countSelectedROB2Buttons(page, 'N'),
-      round1Count: 3,
-      round2Count: 2,
-    });
+    //
+    // The setup context stays open through the cycle for the same reason as
+    // the AMSTAR2 test: closing it would destroy an outbox that may still hold
+    // the unsent checklist-creation mutation.
+    try {
+      await runConcurrentEditCycle(browser, scenario, projectId, checklistUrlA, checklistUrlB, {
+        loadedSelector: 'D1',
+        clickA: async (page, count) => {
+          await page.getByRole('button', { name: 'D1', exact: true }).click();
+          await expect(page.getByRole('button', { name: 'Y', exact: true }).first()).toBeVisible({
+            timeout: 5_000,
+          });
+          return clickROB2Buttons(page, 'Y', count);
+        },
+        clickB: async (page, count) => {
+          await page.getByRole('button', { name: 'D1', exact: true }).click();
+          await expect(page.getByRole('button', { name: 'N', exact: true }).first()).toBeVisible({
+            timeout: 5_000,
+          });
+          return clickROB2Buttons(page, 'N', count);
+        },
+        countA: page => countSelectedROB2Buttons(page, 'Y'),
+        countB: page => countSelectedROB2Buttons(page, 'N'),
+        round1Count: 3,
+        round2Count: 2,
+      });
+    } finally {
+      await setupCtx.close();
+    }
   });
 });

--- a/packages/web/e2e/shared-steps.ts
+++ b/packages/web/e2e/shared-steps.ts
@@ -298,16 +298,23 @@ export async function assignReviewers(page: Page) {
 }
 
 /**
- * Adds an outcome in the All Studies tab.
+ * Adds an outcome through the Outcomes sheet in the project header.
  */
 export async function addOutcome(page: Page, name: string) {
   await page.getByRole('tab', { name: /All Studies/i }).click();
   await page.getByText('Outcomes').click();
-  await expect(page.getByRole('button', { name: /Add/i }).last()).toBeVisible({ timeout: 5_000 });
-  await page.getByRole('button', { name: /Add/i }).last().click();
+
+  const sheet = page.getByRole('dialog');
+  await expect(sheet.getByRole('button', { name: /Add/i }).last()).toBeVisible({ timeout: 5_000 });
+  await sheet.getByRole('button', { name: /Add/i }).last().click();
   await page.getByPlaceholder(/outcome/i).fill(name);
   await page.keyboard.press('Enter');
-  await expect(page.getByText(name)).toBeVisible({ timeout: 5_000 });
+  await expect(sheet.getByText(name)).toBeVisible({ timeout: 5_000 });
+
+  // The sheet is modal and nothing else closes it, so its overlay would swallow
+  // every later click on the tabs behind it.
+  await sheet.getByRole('button', { name: 'Close' }).click();
+  await expect(sheet).toBeHidden({ timeout: 5_000 });
 }
 
 /**


### PR DESCRIPTION
Fixes the two e2e failure modes that blocked the production deploy on run [31323180914](https://github.com/InfinityBowman/corates/actions/runs/31323180914) (staging deployed, e2e failed 5/28, `deploy-production` skipped).

## 1. Outcomes sheet left open (4 of the 5 failures)

#540 moved `OutcomeManager` into `OutcomesSheet`, a modal Radix `Sheet`. The `addOutcome` e2e helper was never updated to close it, so its overlay swallowed every subsequent click and the tests sat out the full 180s timeout waiting for a tab behind it:

```
Error: locator.click: Test timeout of 180000ms exceeded.
Call log:
  - waiting for getByRole('tab', { name: /To Do/i })
```

Affected `rob2-workflow`, `robins-i-workflow`, `change-outcome`, and `concurrent-crdt > ROB2`. The helper now scopes its lookups to the sheet and dismisses it before returning.

## 2. Concurrent-CRDT setup context closed too early (the 5th)

`concurrent-crdt > AMSTAR2` failed with `Checklist not found` on User B's page. Not a regression from the recent merges - the same test failed the same way on run [31284744572](https://github.com/InfinityBowman/corates/actions/runs/31284744572), before #540/#541 landed.

The specs closed the setup context right after User B's checklist rendered, guarded by a comment claiming the render proves the update reached the Durable Object. It does not: checklist creation is a fire-and-forget `void client.mutate(...)`, so the render only proves the local optimistic apply. The trace shows roughly 400ms between creation and `setupCtx.close()`, and closing the context destroys the outbox that still held the unsent mutation - so the fresh client in the cycle found nothing on the server.

Both specs now close the setup context in a `finally` after the cycle, keeping its client connected long enough to drain the outbox.

Both changes are test-only; no application code is touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrent editing test flows by allowing pending checklist changes to finish syncing before continuing.
  - Improved outcome creation by ensuring the dialog closes reliably after an outcome is added.
  - Enhanced validation of concurrent checklist edits and outcome selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->