### PR TITLE
sync: surface pending mutations — status badge, unload guard, e2e wait

### DIFF
--- a/packages/docs/audits/sync-pending-visibility-plan-2026-08.md
+++ b/packages/docs/audits/sync-pending-visibility-plan-2026-08.md
@@ -1,0 +1,213 @@
+# Sync pending-mutation visibility: implementation plan
+
+Status: implemented 2026-08-09 (all four phases). Written 2026-08-09, revised same
+day after review (corrected e2e sleep audit, bfcache-safe unload guard, 0.x version
+range, Linear-style indicator). @cf-sync/client 0.1.1 not yet published: corates
+temporarily consumes a packed tarball via a pnpm-workspace.yaml override -- remove
+it and reinstall once 0.1.1 is on the registry. Implementation deltas from the text
+below: checklist/reconcile routes render no project header, so an invisible
+`data-sync-pending` marker in ProjectView covers them for waitForSynced; the
+concurrent-crdt setup also waits before its mid-test login switch, not only before
+closing the context.
+
+## Problem
+
+The sync client holds an outbox of mutations that have been applied optimistically
+but not yet confirmed by the Durable Object. Nothing anywhere can observe it.
+
+Consequences today:
+
+- A user who edits and closes the tab before the ack has work queued in IndexedDB.
+  It replays on their next visit, so it is usually deferred rather than lost -- but
+  it is lost if they never return on that profile, use a private window, clear site
+  data, or the browser evicts IndexedDB (Safari is most aggressive).
+- On a flaky or offline connection the outbox legitimately holds work for minutes.
+  That is the design working, and there is no indication it is happening.
+- A collaborator waiting on that work sees nothing and cannot distinguish "queued on
+  someone else's machine" from "the app lost it". This already happened once: the
+  stranded-backlog incident resolved on 2026-07-13 only after the affected user
+  reconnected.
+- E2E tests have no signal to wait on, so durability waits are hardcoded sleeps
+  (`persistence-recovery.spec.ts:104,158` wait for the outbox to flush; its other
+  sleeps guard different things -- see Phase 4) and `concurrent-crdt.spec.ts` needs
+  a structural workaround to keep an outbox alive.
+
+This is an observability gap, not a durability bug -- with one exception: there is no
+`beforeunload` guard, so the app silently allows walking away from unsent work.
+
+## Why this cannot be solved in corates alone
+
+`SyncClient`'s public surface is `status`, `hydrated`, `whenHydrated`, `cursor`,
+`workspaceId`, `clientId`, `app`, `schema`, `mutate`, `presence`, `subscribeStatus`,
+`subscribeHydrated`, `onBinary`. Nothing exposes the outbox, and the omission is
+deliberate -- the `SyncStatus` doc comment in `packages/client/src/types.ts` reads
+"one value describing the pipe, not any individual mutation".
+
+Tracking the promises app-side does not work. Outbox entries restored from IndexedDB
+are reconstructed with `resolve: noop` (`packages/client/src/client.ts:645`), so after
+any reload the promises are gone while the work is still queued. Outbox length is the
+only measure that is correct across a reload, and only the engine can see it.
+
+## Phase 1 -- `@cf-sync/client` (repo: `cf-sync-engine`)
+
+Additive and non-breaking. No wire-format change, so `@cf-sync/protocol`,
+`@cf-sync/server`, and `@cf-sync/yjs` are untouched and no deploy coordination is
+needed.
+
+In `packages/client/src/client.ts`:
+
+1. Add `#pendingListeners = new Set<(pending: number) => void>()` alongside the
+   existing `#statusListeners` (`:121`).
+2. Add `get pending(): number { return this.#outbox.length }`. Both unpushed entries
+   (`id: null`, queued before the connection synced) and pushed-but-unconfirmed ones
+   count -- the question being answered is "not durably on the server yet".
+3. Add `readonly subscribePending = (listener: (pending: number) => void) => ...`,
+   copying the shape of `subscribeStatus` (`:360`) exactly. Keep it an arrow property
+   so it drops into `useSyncExternalStore` unbound, and document it the same way.
+4. Add a private `#notifyPending()` and call it wherever `#outbox` changes.
+   `#settleEntry` (`:1442`) is the removal chokepoint -- the shutdown loop (`:516`,
+   inside `#shutdown()`, reached from both `stop()` and `destroy()`), the confirm
+   sweep (`:1419`), and the fatal path (`:1652`) all go through it, so
+   instrumenting it plus the two growth sites covers everything:
+   - `:653` -- hydration prepends restored entries
+   - `:945` -- `mutate()` pushes a new entry
+   - `:1442` -- `#settleEntry` removes one entry
+     Emit only when the count actually changed, so listeners do not churn.
+5. Optional, and only if a call site wants it: `whenIdle(): Promise<void>` resolving
+   when `pending` hits 0. Skip unless something needs it -- `subscribePending` covers
+   the UI and the tests.
+
+Export nothing new from `packages/client/src/index.ts`; these are members of the
+already-exported `SyncClient`.
+
+Tests in `packages/client/test/` (follow `persistence.test.ts` and
+`startup-replay.test.ts`, which already drive the outbox):
+
+- `pending` is 0 on a fresh client, 1 after a `mutate` that has not been confirmed,
+  back to 0 after the confirm poke.
+- `subscribePending` fires on both transitions and stops firing after unsubscribe.
+- **The reload case, which is the whole reason this lives in the engine**: mutate with
+  a store attached, stop the client before confirmation, construct a new client over
+  the same store, and assert `pending` is 1 after hydration -- the restored entry has
+  no promise but must still count.
+- `destroy()` drops `pending` to 0.
+
+Then publish. corates consumes `@cf-sync/client ^0.1.0` from the registry, not a
+workspace link, so the app cannot use this until it ships. Version carefully: for
+0.x packages a caret range does not cross the minor, so `0.2.0` falls outside
+`^0.1.0`. Either publish as `0.1.x` or bump the range in corates' package.json as
+part of Phase 2. The global `minimumReleaseAge` rule has a standing exception for
+Jacob's own `cf-sync-*` packages, so the 4-day wait does not apply. To iterate
+before publishing, point a pnpm override at the sibling checkout.
+
+## Phase 2 -- corates: store plumbing and the `beforeunload` guard
+
+This phase is where the one real safety gap gets closed. Do not skip ahead to the UI.
+
+1. `packages/web/src/stores/projectStore.ts`: add `pending: number` to
+   `ConnectionMachineState` (`:17`), defaulted to 0 in `INITIAL_CONNECTION` (`:22`).
+   Add a `setPending(projectId, pending)` action next to `setConnectionState` (`:152`)
+   rather than widening that setter -- phase and pending change on different events.
+2. `packages/web/src/project/ConnectionPool.ts`: in `startConnection`, subscribe
+   alongside the existing status/hydrated subscriptions (`:223-225`) and push the
+   unsubscribe onto `entry._cleanupHandlers` the same way:
+
+   ```ts
+   entry._cleanupHandlers.push(
+     workspace.client.subscribePending(pending => {
+       if (cancelled()) return;
+       useProjectStore.getState().setPending(projectId, pending);
+     }),
+   );
+   ```
+
+   Seed it with the current value immediately after, mirroring the existing
+   `applyStatus(workspace.client.status)` call.
+
+3. Add the `beforeunload` guard. `ConnectionPool` already owns a `pagehide` listener
+   at module scope (`:468-470`); put the wiring beside it, but do not register the
+   listener permanently -- a page with a `beforeunload` handler is ineligible for
+   back/forward cache in Safari and Firefox. Add the listener when total pending
+   across the registry transitions from 0 to positive and remove it when it returns
+   to 0 (the `subscribePending` subscriptions from step 2 are the natural trigger).
+   The handler itself just calls `preventDefault()`. Note that browsers show their
+   own generic wording -- a custom string is ignored -- so this is a speed bump, not
+   a message channel.
+
+Verify by hand: throttle the network to offline in devtools, make an edit, confirm the
+store's pending count rises and the tab refuses to close silently.
+
+## Phase 3 -- corates: the indicator
+
+Linear-style: show nothing while healthy, surface only the exceptional state. This
+is what Linear and Notion both do -- no "Saving...", no "Saved", just an offline or
+unsent-work badge when something is actually wrong. A "Saved" ticker is the Google
+Docs pattern, and it makes a promise this app cannot keep (see the wording note
+below). Silence makes no promise.
+
+Place it in `ProjectHeader` (`packages/web/src/components/project/ProjectHeader.tsx`),
+near `ProjectHeaderActions` (`:128`). An always-rendered status container (empty and
+invisible in the healthy state -- Phase 4 needs the element to exist) with one badge
+that appears when:
+
+- pending > 0 and phase is not `synced` -- "Offline -- changes pending", or
+- pending has been continuously above 0 for ~10s while `synced` -- "Unsent changes"
+  (the pipe looks fine but work is not landing; this is the stranded-backlog shape)
+
+Everything else renders nothing. The ~10s escalation timer lives in the component,
+driven by the raw store value -- not in the store and not in the engine.
+
+**Why no "Saved" state.** The pending count covers mutations only. Reconciliation
+notes travel the Yjs binary lane, which has no ack at all (see Out of scope), so any
+positive confirmation ("Saved", "All changes saved") would be lying about notes. An
+indicator that only ever warns about unsent mutations is scoped to exactly what
+`pending` measures. If users turn out to want positive confirmation, a muted synced
+state can be added later -- adding reassurance is easy, walking back a false promise
+is not.
+
+## Phase 4 -- corates: e2e
+
+1. Expose pending to the DOM rather than widening a global. `window.__connectionPool`
+   is gated on `import.meta.env.DEV` (`ConnectionPool.ts:472`) and therefore does not
+   exist on staging, where the suite actually runs. Put a `data-sync-pending`
+   attribute on the always-rendered status container from Phase 3 -- Playwright then
+   gets auto-retrying `toHaveAttribute` for free and no debug global ships in the
+   production bundle. The attribute carries the raw pending count, not any debounced
+   or escalated display state, so tests never wait out UI timers.
+2. Add `waitForSynced(page)` to `packages/web/e2e/shared-steps.ts`, asserting
+   `data-sync-pending="0"`.
+3. Replace the true durability sleeps with it: `persistence-recovery.spec.ts:104` and
+   `:158`, both of which wait for the outbox to flush to the server. The other four
+   sleeps in that file are not replaceable and stay:
+   - `:212` and `:241` wait for the engine's IndexedDB snapshot flush before a
+     reload. Pending hitting 0 means the server confirmed -- a different property --
+     and `:241` is taken while the page is offline, where pending never reaches 0
+     and `waitForSynced` would hang until timeout.
+   - `:335` and `:341` belong to the negative-repro test for the "No active project
+     connection" bug: `:335` deliberately waits past any sync window to prove the
+     failure is not a race, and `:341` follows a mutation that is expected to fail.
+     Leave the small UI-settle sleeps in `concurrent-crdt.spec.ts:59,94` and
+     `realtime-collaboration.spec.ts` alone too -- none of these are durability waits.
+4. Revisit `concurrent-crdt.spec.ts`. The setup context is currently held open through
+   the whole cycle purely so its outbox can drain (added 2026-08-09, PR #544). With a
+   real signal it can go back to closing early, right after `await waitForSynced(setupPage)`.
+
+## Out of scope
+
+The Yjs binary lane has no acknowledgement of any kind. `sendUpdate` goes out via
+`client.sendBinary(...)` (`cf-sync-engine/packages/yjs/src/client.ts:181`), whose
+signature is `sendBinary(bytes): void`, and `YjsFieldHandle` exposes only `doc`,
+`text`, `canWrite`, `writeBlocked`, `whenSynced`, `subscribe`, `release`. `whenSynced`
+resolves on the first STATE and stays resolved, so it answers "can I render this
+field", not "is my edit safe". Recovery is the STATE push-back on reconnect.
+
+Giving notes a pending count needs a real protocol change -- an ack frame or a
+server-echoed state vector -- across `@cf-sync/protocol`, `@cf-sync/server`, and
+`@cf-sync/yjs`. Do it only if notes are observed going missing. Until then it is a
+known blind spot that Phase 3's wording has to respect.
+
+## Sequencing
+
+Phase 1 gates everything. Phase 2 is the only phase that fixes a real safety gap and
+should not wait on the UI work. Phases 3 and 4 are independent of each other once 2
+lands.

--- a/packages/web/e2e/concurrent-crdt.spec.ts
+++ b/packages/web/e2e/concurrent-crdt.spec.ts
@@ -32,6 +32,7 @@ import {
   assignReviewers,
   addOutcome,
   fillROB2Preliminary,
+  waitForSynced,
 } from './shared-steps';
 import { BASE_URL } from './constants';
 
@@ -271,6 +272,8 @@ test.describe('Concurrent CRDT: AMSTAR2', () => {
     const checklistUrlA = new URL(setupPage.url()).pathname;
     await setupPage.goto(`${BASE_URL}/projects/${projectId}`);
     await expect(setupPage.getByRole('tab', { name: /To Do/i })).toBeVisible({ timeout: 15_000 });
+    // User A's checklist creation must be durable before the login switch.
+    await waitForSynced(setupPage);
 
     // Switch to User B
     await setupCtx.clearCookies();
@@ -294,24 +297,21 @@ test.describe('Concurrent CRDT: AMSTAR2', () => {
     await setupPage.goto(`${BASE_URL}/projects/${projectId}`);
     await expect(setupPage.getByRole('tab', { name: /To Do/i })).toBeVisible({ timeout: 15_000 });
 
-    // Hold the setup context open through the cycle. Checklist creation is a
-    // fire-and-forget mutation, so a rendered checklist only proves the local
-    // optimistic apply happened -- the outbox entry may still be unsent, and
-    // closing the context destroys the only copy of it. Keeping the client
-    // connected lets the outbox drain while the cycle's own contexts start up.
-    try {
-      await runConcurrentEditCycle(browser, scenario, projectId, checklistUrlA, checklistUrlB, {
-        loadedSelector: 'AMSTAR2 Checklist',
-        clickA: (page, count) => clickUncheckedCheckboxes(page, count),
-        clickB: (page, count) => clickUncheckedCheckboxes(page, count),
-        countA: page => countCheckedCheckboxes(page),
-        countB: page => countCheckedCheckboxes(page),
-        round1Count: 5,
-        round2Count: 3,
-      });
-    } finally {
-      await setupCtx.close();
-    }
+    // Checklist creation is a fire-and-forget mutation; a rendered checklist
+    // only proves the local optimistic apply. Wait for the outbox to drain
+    // before closing the context that holds it.
+    await waitForSynced(setupPage);
+    await setupCtx.close();
+
+    await runConcurrentEditCycle(browser, scenario, projectId, checklistUrlA, checklistUrlB, {
+      loadedSelector: 'AMSTAR2 Checklist',
+      clickA: (page, count) => clickUncheckedCheckboxes(page, count),
+      clickB: (page, count) => clickUncheckedCheckboxes(page, count),
+      countA: page => countCheckedCheckboxes(page),
+      countB: page => countCheckedCheckboxes(page),
+      round1Count: 5,
+      round2Count: 3,
+    });
   });
 });
 
@@ -376,6 +376,8 @@ test.describe('Concurrent CRDT: ROB2', () => {
     const checklistUrlA = new URL(setupPage.url()).pathname;
     await setupPage.goto(`${BASE_URL}/projects/${projectId}`);
     await expect(setupPage.getByRole('tab', { name: /To Do/i })).toBeVisible({ timeout: 15_000 });
+    // User A's checklist creation must be durable before the login switch.
+    await waitForSynced(setupPage);
 
     // Switch to User B
     await setupCtx.clearCookies();
@@ -405,38 +407,36 @@ test.describe('Concurrent CRDT: ROB2', () => {
     });
     await fillROB2Preliminary(setupPage, 'Drug B', 'Standard care');
 
+    // Checklist creation and the preliminary answers are fire-and-forget
+    // mutations; wait for the outbox to drain before closing the context
+    // that holds it.
+    await waitForSynced(setupPage);
+    await setupCtx.close();
+
     // ROB2 uses toggle buttons (Y/PY/PN/N/NI) instead of radios.
     // Expand D1 on both pages before clicking, since domain sections
     // are collapsible. The concurrent cycle will click within D1's
     // visible signalling questions.
-    //
-    // The setup context stays open through the cycle for the same reason as
-    // the AMSTAR2 test: closing it would destroy an outbox that may still hold
-    // the unsent checklist-creation mutation.
-    try {
-      await runConcurrentEditCycle(browser, scenario, projectId, checklistUrlA, checklistUrlB, {
-        loadedSelector: 'D1',
-        clickA: async (page, count) => {
-          await page.getByRole('button', { name: 'D1', exact: true }).click();
-          await expect(page.getByRole('button', { name: 'Y', exact: true }).first()).toBeVisible({
-            timeout: 5_000,
-          });
-          return clickROB2Buttons(page, 'Y', count);
-        },
-        clickB: async (page, count) => {
-          await page.getByRole('button', { name: 'D1', exact: true }).click();
-          await expect(page.getByRole('button', { name: 'N', exact: true }).first()).toBeVisible({
-            timeout: 5_000,
-          });
-          return clickROB2Buttons(page, 'N', count);
-        },
-        countA: page => countSelectedROB2Buttons(page, 'Y'),
-        countB: page => countSelectedROB2Buttons(page, 'N'),
-        round1Count: 3,
-        round2Count: 2,
-      });
-    } finally {
-      await setupCtx.close();
-    }
+    await runConcurrentEditCycle(browser, scenario, projectId, checklistUrlA, checklistUrlB, {
+      loadedSelector: 'D1',
+      clickA: async (page, count) => {
+        await page.getByRole('button', { name: 'D1', exact: true }).click();
+        await expect(page.getByRole('button', { name: 'Y', exact: true }).first()).toBeVisible({
+          timeout: 5_000,
+        });
+        return clickROB2Buttons(page, 'Y', count);
+      },
+      clickB: async (page, count) => {
+        await page.getByRole('button', { name: 'D1', exact: true }).click();
+        await expect(page.getByRole('button', { name: 'N', exact: true }).first()).toBeVisible({
+          timeout: 5_000,
+        });
+        return clickROB2Buttons(page, 'N', count);
+      },
+      countA: page => countSelectedROB2Buttons(page, 'Y'),
+      countB: page => countSelectedROB2Buttons(page, 'N'),
+      round1Count: 3,
+      round2Count: 2,
+    });
   });
 });

--- a/packages/web/e2e/persistence-recovery.spec.ts
+++ b/packages/web/e2e/persistence-recovery.spec.ts
@@ -21,7 +21,7 @@ import {
   updateSubscription,
   type DualReviewerScenario,
 } from './helpers';
-import { setupProjectWithStudy, studyCardTitle } from './shared-steps';
+import { setupProjectWithStudy, studyCardTitle, waitForSynced } from './shared-steps';
 
 let scenario: DualReviewerScenario;
 
@@ -100,8 +100,8 @@ test('Project state survives page refresh', async ({ context, page }) => {
     await yesRadios.nth(i).click();
     await expect(yesRadios.nth(i)).toBeChecked({ timeout: 5_000 });
   }
-  // Give the WebSocket time to flush updates to the server
-  await page.waitForTimeout(1000);
+  // Every answer is durably on the server once the outbox drains.
+  await waitForSynced(page);
 
   const checkedAfterRound1 = await countCheckedYesRadios(page);
   expect(checkedAfterRound1).toBeGreaterThan(0);
@@ -155,7 +155,7 @@ test('Project state survives page refresh', async ({ context, page }) => {
     await yesRadiosRound2.nth(i).click();
     await expect(yesRadiosRound2.nth(i)).toBeChecked({ timeout: 5_000 });
   }
-  await page.waitForTimeout(1000);
+  await waitForSynced(page);
 
   const checkedAfterRound2 = await countCheckedYesRadios(page);
   expect(checkedAfterRound2).toBeGreaterThan(checkedAfterReload1);

--- a/packages/web/e2e/shared-steps.ts
+++ b/packages/web/e2e/shared-steps.ts
@@ -318,6 +318,22 @@ export async function addOutcome(page: Page, name: string) {
 }
 
 /**
+ * Waits until the project's sync outbox is empty: every mutation issued on
+ * this page (including entries restored from IndexedDB) is durably on the
+ * server. `data-sync-pending` carries the raw outbox count -- rendered by
+ * SyncStatusIndicator in the project header, and by an invisible marker on
+ * checklist/reconcile routes, which have no project header.
+ *
+ * This covers mutations only. Yjs binary updates (reconciliation notes) have
+ * no acknowledgement, so this cannot wait on them.
+ */
+export async function waitForSynced(page: Page, timeout = 15_000) {
+  await expect(page.locator('[data-sync-pending]')).toHaveAttribute('data-sync-pending', '0', {
+    timeout,
+  });
+}
+
+/**
  * Marks the current checklist as complete and handles the confirmation dialog.
  * The dialog says "Mark Appraisal as Complete?" with a "Mark Complete" action button.
  */

--- a/packages/web/src/components/project/ProjectHeader.tsx
+++ b/packages/web/src/components/project/ProjectHeader.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { InlineEdit } from '@/components/ui/inline-edit';
 import { ProjectHeaderActions } from './ProjectHeaderActions';
+import { SyncStatusIndicator } from './SyncStatusIndicator';
 
 interface ProjectHeaderProps {
   name?: string;
@@ -125,7 +126,10 @@ export function ProjectHeader({
         </div>
       </div>
 
-      <ProjectHeaderActions />
+      <div className='flex items-center gap-3'>
+        <SyncStatusIndicator />
+        <ProjectHeaderActions />
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/project/ProjectView.tsx
+++ b/packages/web/src/components/project/ProjectView.tsx
@@ -310,8 +310,14 @@ function ProjectViewInner({ projectId }: ProjectViewProps) {
 
   return (
     <>
-      {/* Child routes */}
-      {isChildRoute && <Outlet />}
+      {/* Child routes render no project header, so the sync-pending marker the
+          e2e suite waits on (see shared-steps waitForSynced) lives here. */}
+      {isChildRoute && (
+        <>
+          <div data-sync-pending={connectionState.pending} hidden />
+          <Outlet />
+        </>
+      )}
 
       {/* Main project view */}
       {!isChildRoute && (

--- a/packages/web/src/components/project/SyncStatusIndicator.tsx
+++ b/packages/web/src/components/project/SyncStatusIndicator.tsx
@@ -1,0 +1,59 @@
+/**
+ * SyncStatusIndicator - Exceptional-state-only sync badge.
+ *
+ * Silent while healthy (Linear-style): rendering save mechanics on every
+ * keystroke trains users to ignore them. The container always renders so
+ * e2e can wait on `data-sync-pending` reaching 0 (see shared-steps
+ * waitForSynced); the badge inside appears only when unsent work needs
+ * attention. No positive "Saved" state on purpose -- the pending count
+ * covers mutations only, not the Yjs note lane, so a blanket "saved" claim
+ * would overpromise.
+ */
+
+import { useEffect, useState } from 'react';
+import { CloudOffIcon, CloudAlertIcon } from 'lucide-react';
+import { useProjectContext } from './ProjectContext';
+import { useProjectStore } from '@/stores/projectStore';
+import { Badge } from '@/components/ui/badge';
+
+// How long mutations may sit unconfirmed on a synced connection before the
+// pipe-looks-fine-but-work-is-not-landing badge shows.
+const ESCALATE_AFTER_MS = 10_000;
+
+export function SyncStatusIndicator() {
+  const { projectId } = useProjectContext();
+  const connection = useProjectStore(state => state.connections[projectId]);
+  const phase = connection?.phase ?? 'idle';
+  const pending = connection?.pending ?? 0;
+
+  const hasPending = pending > 0;
+  const offline = hasPending && phase !== 'synced';
+  const [stalled, setStalled] = useState(false);
+
+  useEffect(() => {
+    if (!hasPending || phase !== 'synced') {
+      setStalled(false);
+      return;
+    }
+    // Keyed on hasPending, not the count, so a draining outbox (3, 2, 1)
+    // does not keep resetting the escalation clock.
+    const timer = setTimeout(() => setStalled(true), ESCALATE_AFTER_MS);
+    return () => clearTimeout(timer);
+  }, [hasPending, phase]);
+
+  return (
+    <div role='status' data-sync-pending={pending} className='flex items-center'>
+      {offline ?
+        <Badge variant='warning'>
+          <CloudOffIcon className='size-3' />
+          Offline, changes pending
+        </Badge>
+      : stalled ?
+        <Badge variant='warning'>
+          <CloudAlertIcon className='size-3' />
+          Unsent changes
+        </Badge>
+      : null}
+    </div>
+  );
+}

--- a/packages/web/src/primitives/__tests__/projectStore.test.ts
+++ b/packages/web/src/primitives/__tests__/projectStore.test.ts
@@ -14,7 +14,7 @@ describe('projectStore connection state', () => {
 
   it('starts idle for unknown projects', () => {
     const state = selectConnectionPhase(useProjectStore.getState(), PROJECT);
-    expect(state).toEqual({ phase: 'idle', error: null });
+    expect(state).toEqual({ phase: 'idle', error: null, pending: 0 });
   });
 
   it('stores phase transitions from the pool', () => {
@@ -45,7 +45,27 @@ describe('projectStore connection state', () => {
     expect(selectConnectionPhase(useProjectStore.getState(), PROJECT)).toEqual({
       phase: 'connecting',
       error: null,
+      pending: 0,
     });
+  });
+
+  it('setPending creates the record and survives phase changes', () => {
+    const store = useProjectStore.getState();
+    store.setPending(PROJECT, 2);
+    expect(selectConnectionPhase(useProjectStore.getState(), PROJECT)).toEqual({
+      phase: 'idle',
+      error: null,
+      pending: 2,
+    });
+
+    // Phase and pending change on different events; neither clobbers the other.
+    store.setConnectionState(PROJECT, 'synced');
+    expect(selectConnectionPhase(useProjectStore.getState(), PROJECT).pending).toBe(2);
+
+    store.setPending(PROJECT, 0);
+    const state = selectConnectionPhase(useProjectStore.getState(), PROJECT);
+    expect(state.phase).toBe('synced');
+    expect(state.pending).toBe(0);
   });
 
   it('clearProject removes the record and active pointer', () => {

--- a/packages/web/src/project/ConnectionPool.ts
+++ b/packages/web/src/project/ConnectionPool.ts
@@ -224,6 +224,16 @@ class ConnectionPool {
       workspace.client.subscribeHydrated(() => applyStatus(workspace.client.status)),
     );
     applyStatus(workspace.client.status);
+
+    entry._cleanupHandlers.push(
+      workspace.client.subscribePending(pending => {
+        if (cancelled()) return;
+        useProjectStore.getState().setPending(projectId, pending);
+        this.updateUnloadGuard();
+      }),
+    );
+    useProjectStore.getState().setPending(projectId, workspace.client.pending);
+    this.updateUnloadGuard();
   }
 
   /**
@@ -455,12 +465,42 @@ class ConnectionPool {
     if (entry.workspace) void entry.workspace.destroy();
 
     this.registry.delete(projectId);
+    this.updateUnloadGuard();
     // Keep the error phase visible through the redirect effect; a fresh mount
     // starts from a clean record either way.
     if (!options.keepErrorState) {
       useProjectStore.getState().clearProject(projectId);
     }
   }
+
+  /**
+   * Unconfirmed work in any session's outbox survives a reload but not a
+   * profile the user never returns on, so closing the tab over it deserves
+   * the browser's leave-site prompt.
+   */
+  private updateUnloadGuard(): void {
+    let total = 0;
+    for (const entry of this.registry.values()) {
+      total += entry.workspace?.client.pending ?? 0;
+    }
+    setUnloadGuard(total > 0);
+  }
+}
+
+// The guard is registered only while unsent work exists: a standing
+// beforeunload handler makes the page ineligible for back/forward cache in
+// Safari and Firefox. Browsers ignore custom wording, so preventDefault is
+// the whole message.
+const unloadGuard = (event: Event) => {
+  event.preventDefault();
+};
+let unloadGuardActive = false;
+
+function setUnloadGuard(active: boolean): void {
+  if (typeof window === 'undefined' || active === unloadGuardActive) return;
+  unloadGuardActive = active;
+  if (active) window.addEventListener('beforeunload', unloadGuard);
+  else window.removeEventListener('beforeunload', unloadGuard);
 }
 
 export const connectionPool = new ConnectionPool();

--- a/packages/web/src/stores/projectStore.ts
+++ b/packages/web/src/stores/projectStore.ts
@@ -17,9 +17,11 @@ export type ConnectionPhase = 'idle' | 'connecting' | 'cached' | 'synced' | 'err
 export interface ConnectionMachineState {
   phase: ConnectionPhase;
   error: string | null;
+  /** Mutations applied locally but not yet confirmed durable by the server. */
+  pending: number;
 }
 
-const INITIAL_CONNECTION: ConnectionMachineState = { phase: 'idle', error: null };
+const INITIAL_CONNECTION: ConnectionMachineState = { phase: 'idle', error: null, pending: 0 };
 
 export interface PdfEntry {
   id: string;
@@ -136,6 +138,7 @@ interface ProjectStoreState {
 interface ProjectStoreActions {
   setActiveProject: (projectId: string | null) => void;
   setConnectionState: (projectId: string, phase: ConnectionPhase, error?: string | null) => void;
+  setPending: (projectId: string, pending: number) => void;
   clearProject: (projectId: string) => void;
 }
 
@@ -151,7 +154,19 @@ export const useProjectStore = create<ProjectStoreState & ProjectStoreActions>()
 
     setConnectionState: (projectId, phase, error = null) =>
       set(state => {
-        state.connections[projectId] = { phase, error };
+        // Phase and pending change on different events; keep the count.
+        const pending = state.connections[projectId]?.pending ?? 0;
+        state.connections[projectId] = { phase, error, pending };
+      }),
+
+    setPending: (projectId, pending) =>
+      set(state => {
+        const current = state.connections[projectId];
+        if (current) {
+          current.pending = pending;
+        } else {
+          state.connections[projectId] = { ...INITIAL_CONNECTION, pending };
+        }
       }),
 
     clearProject: projectId =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         version: 5.38.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@cf-sync/client':
         specifier: ^0.1.0
-        version: 0.1.0(@tanstack/db@0.6.17(typescript@5.9.3))(@tanstack/react-db@0.1.95(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(zod@4.4.3)
+        version: 0.1.1(@tanstack/db@0.6.17(typescript@5.9.3))(@tanstack/react-db@0.1.95(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(zod@4.4.3)
       '@cf-sync/yjs':
         specifier: ^0.2.0
         version: 0.2.0(@cf-sync/server@0.2.0(zod@4.4.3))(react@19.2.8)(yjs@13.6.32)(zod@4.4.3)
@@ -833,8 +833,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@cf-sync/client@0.1.0':
-    resolution: {integrity: sha512-isODUJnEwEtVdjePfMkPBokzFi9eIjdiZEe0jxS9AFFEWaxrGMU0i0caPHKXaFiq2r4vL8tHdOYBITMWXeu9fg==}
+  '@cf-sync/client@0.1.1':
+    resolution: {integrity: sha512-68C+Yois8Abq1BnBbrOMIhkGOb2Nt1vbMQGu1yZSlhr3tUv2kQQjxF8tSg09/MNNGtAgDOWuhN3N22mFlMKVDQ==}
     peerDependencies:
       '@tanstack/db': ^0.6.16
       '@tanstack/react-db': ^0.1.94
@@ -9183,7 +9183,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@cf-sync/client@0.1.0(@tanstack/db@0.6.17(typescript@5.9.3))(@tanstack/react-db@0.1.95(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(zod@4.4.3)':
+  '@cf-sync/client@0.1.1(@tanstack/db@0.6.17(typescript@5.9.3))(@tanstack/react-db@0.1.95(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(zod@4.4.3)':
     dependencies:
       '@cf-sync/protocol': 0.1.1(zod@4.4.3)
       '@tanstack/db': 0.6.17(typescript@5.9.3)


### PR DESCRIPTION
## Summary

The sync client's outbox of optimistic-but-unconfirmed mutations was unobservable: queued work on a flaky connection was indistinguishable from lost work (the stranded-backlog incident), nothing stopped a user from closing the tab over unsent changes, and e2e durability waits were hardcoded sleeps. `@cf-sync/client` 0.1.1 exposes the outbox depth as `pending`/`subscribePending` (the count survives reload; promises do not); this PR consumes it.

Full plan with review notes: `packages/docs/audits/sync-pending-visibility-plan-2026-08.md`

## Changes

- **projectStore**: `pending` on `ConnectionMachineState` with a dedicated `setPending` action; `setConnectionState` preserves the count since phase and pending change on different events.
- **ConnectionPool**: subscribes per connection and maintains a `beforeunload` guard that is registered only while total pending is above zero — a standing handler would make the page ineligible for back/forward cache in Safari and Firefox.
- **SyncStatusIndicator** (new, in `ProjectHeader`): Linear-style, exceptional-state-only. Shows "Offline, changes pending" when unsent work exists off-sync, and "Unsent changes" when pending sits nonzero for ~10s while synced. Silent otherwise, and deliberately no "Saved" state: the count covers mutations only, not the un-acked Yjs note lane.
- **e2e**: `waitForSynced` in shared-steps asserts `data-sync-pending="0"` (raw count, never debounced). Checklist/reconcile routes render no project header, so `ProjectView` emits an invisible marker there. Replaces the two true outbox-drain sleeps in `persistence-recovery.spec.ts`; the other four sleeps guard different things (IndexedDB flush, negative-repro) and stay. The concurrent-crdt setup context closes early again, gated on the real durability signal — reverts the #544 hold-open workaround.

## Verification

- Engine: 144/144 tests (4 new in `pending.test.ts`, including the reload-restore case)
- corates: typecheck and lint clean, 330/330 unit/server tests
- Full e2e suite against dev: 30/30
- Lockfile now resolves published `@cf-sync/client@0.1.1`; the temporary tarball override is removed

Manual check still worth doing on review: throttle offline, edit, confirm the badge appears and the tab prompts before closing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sync status visibility to project headers.
  * Displays warnings when changes are offline or remain unsent.
  * Prevents accidental page closure while online changes are still pending.
  * Improved synchronization handling for concurrent editing and recovery scenarios.

* **Bug Fixes**
  * More accurately tracks pending changes across connection state updates.
  * Replaced timing-based synchronization checks with reliable sync completion detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->